### PR TITLE
Improve built articles

### DIFF
--- a/src/build/articles.js
+++ b/src/build/articles.js
@@ -4,13 +4,10 @@ import process from "process";
 function readAssetsArticlesFiles(articlesPath) {
     let files = fs.readdirSync(articlesPath);
     files = files.filter((file) => file.split(".").at(-1) === "html");
-    const articles = [];
+    const articles = {};
     files.forEach((file) => {
-        articles.push({
-            name: file.slice(0, -5),
-            content: fs.readFileSync(articlesPath + file, {
-                encoding: "utf8",
-            }),
+        articles[file.slice(0, -5)] = fs.readFileSync(articlesPath + file, {
+            encoding: "utf8",
         });
     });
     return articles;

--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -8,16 +8,9 @@ export function detectArticle() {
     const params = new URLSearchParams(window.location.search);
     const query = params.get("article");
 
-    if (!query) {
-        container.innerHTML = "";
+    if (articles[query]) {
+        container.innerHTML = articles[query];
         return;
-    }
-
-    for (let i = 0; i < articles.length; i++) {
-        if (articles[i].name === query) {
-            container.innerHTML = articles[i].content;
-            return;
-        }
     }
 
     container.innerHTML = "";

--- a/tests/anchors-to-articles.test.js
+++ b/tests/anchors-to-articles.test.js
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
 import { articles } from "../src/content/articles.js";
 
 describe("anchors to articles", () => {
+    const someArticle = Object.entries(articles)[0];
+
     beforeEach(async () => {
         document.body.innerHTML = `
             <div id="article-container"></div>
-            <a id="test" toarticle="${articles[0].name}"></a>"
+            <a id="test" toarticle="${someArticle[0]}"></a>"
         `;
         await import("../src/main.js");
         document.getElementById("test").click();
@@ -14,7 +16,7 @@ describe("anchors to articles", () => {
     test("should update search params and load article", () => {
         const container = document.getElementById("article-container");
         const params = new URL(document.location.href).searchParams;
-        expect(container.innerHTML).toBe(articles[0].content);
-        expect(params.get("article")).toBe(articles[0].name);
+        expect(container.innerHTML).toBe(someArticle[1]);
+        expect(params.get("article")).toBe(someArticle[0]);
     });
 });

--- a/tests/article-on-load.test.js
+++ b/tests/article-on-load.test.js
@@ -4,18 +4,20 @@ import { articles } from "../src/content/articles.js";
 import fs from "fs";
 
 describe("article on load", () => {
+    const someArticle = Object.entries(articles)[0];
+
     beforeEach(async () => {
         document.body.innerHTML = fs.readFileSync("./index.html", {
             encoding: "utf8",
         });
-        changeSearchParam("article", articles[0].name);
+        changeSearchParam("article", someArticle[0]);
         await import("../src/main.js");
     });
 
     test("should load article on start", () => {
         const container = document.getElementById("article-container");
         const params = new URL(document.location.href).searchParams;
-        expect(container.innerHTML).toBe(articles[0].content);
-        expect(params.get("article")).toBe(articles[0].name);
+        expect(container.innerHTML).toBe(someArticle[1]);
+        expect(params.get("article")).toBe(someArticle[0]);
     });
 });

--- a/tests/articles-anchor-links.test.js
+++ b/tests/articles-anchor-links.test.js
@@ -2,21 +2,20 @@ import { describe, expect, test } from "@jest/globals";
 import { articles } from "../src/content/articles.js";
 
 describe("articles anchor links", () => {
-    describe.each(articles)("$name", ({ content }) => {
+    const scenarios = Object.entries(articles).map((entry) => ({
+        name: entry[0],
+        content: entry[1],
+    }));
+
+    describe.each(scenarios)("$name", ({ content }) => {
         document.body.innerHTML = `${content}`;
         const anchors = document.querySelectorAll("a");
         const badLinks = [];
         anchors.forEach((a) => {
             const target = a.getAttribute("toarticle");
-            let found = false;
-            if (target) {
-                for (let i = 0; i < articles.length; i++) {
-                    if (articles[i].name === target) {
-                        found = true;
-                    }
-                }
+            if (!Object.hasOwn(articles, target)) {
+                badLinks.push(target);
             }
-            if (!found) badLinks.push(target);
         });
 
         test("should not have bad links", () => {

--- a/tests/build-articles.test.js
+++ b/tests/build-articles.test.js
@@ -87,11 +87,7 @@ describe("buildArticles", () => {
                 result.data = data;
             });
             expectedData =
-                "export default " +
-                JSON.stringify([
-                    { name: "file", content: "" },
-                    { name: "other", content: "" },
-                ]);
+                "export default " + JSON.stringify({ file: "", other: "" });
             buildArticles(articlesPath, buildPath);
         });
 


### PR DESCRIPTION
Currently, they're an array of objects with a name and a content key. Obviously, they should have been just an object with every key being its name and having the content as its value.

This way, we don't need to iterate through the array looking for the name of the article, you just access it directly through the hashmap.