### PR TITLE
Implement maps

### DIFF
--- a/assets/articles/test.html
+++ b/assets/articles/test.html
@@ -1,2 +1,3 @@
 <h1>Test Article</h1>
 <p>This is a test article. Click <a toarticle="another-test">this link</a> to go the another test.</p>
+<p>Lorem ipsum dolor <a tomap="map1">click here</a> to go to map1 or <a tomap="map2">here</a> to go to map2.</p>

--- a/assets/maps/map2.json
+++ b/assets/maps/map2.json
@@ -1,5 +1,5 @@
 {
-    "name": "Map One",
+    "name": "Map Two",
     "image": "map1.png",
     "links": [
         {
@@ -14,7 +14,7 @@
         {
             "name": "Another Test",
             "size": "medium",
-            "tomap": "map2",
+            "tomap": "map1",
             "pos": {
                 "x": "70%",
                 "y": "60%"
@@ -23,7 +23,7 @@
         {
             "name": "Test Article Small",
             "size": "small",
-            "tomap": "map2",
+            "tomap": "map1",
             "toarticle": "test",
             "pos": {
                 "x": "33%",

--- a/index.html
+++ b/index.html
@@ -10,17 +10,10 @@
         <script type="module" src="src/main.js"></script>
     </head>
 
-    <body class="bg-bg-light dark:bg-bg-dark">
-        <div id="map-container"></div>
-        <div class="flex m-4">
-            <button onclick="window.toArticle('')">clear</button>
-            <button class="ml-4" onclick="window.toArticle('test')">
-                test
-            </button>
-            <button class="ml-4" onclick="window.toArticle('another-test')">
-                another test
-            </button>
-        </div>
-        <div id="article-container"></div>
+    <body
+        class="bg-bg-light dark:bg-bg-dark min-h-screen min-w-screen relative"
+    >
+        <div id="map-container" class="h-full w-full"></div>
+        <div id="article-container" class="absolute"></div>
     </body>
 </html>

--- a/scripts/build-maps.js
+++ b/scripts/build-maps.js
@@ -6,9 +6,11 @@ function readAssetsMapsFiles(mapsPath) {
     files = files.filter((file) => file.split(".").at(-1) === "json");
     const maps = {};
     files.forEach((file) => {
-        maps[file.slice(0, -5)] = fs.readFileSync(mapsPath + file, {
-            encoding: "utf8",
-        });
+        maps[file.slice(0, -5)] = JSON.parse(
+            fs.readFileSync(mapsPath + file, {
+                encoding: "utf8",
+            }),
+        );
     });
     return maps;
 }

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -8,11 +8,21 @@ export function setAnchors() {
     const anchors = document.querySelectorAll("a");
     anchors.forEach((a) => {
         const article = a.getAttribute("toarticle");
+        const map = a.getAttribute("tomap");
+        if (!article && !map) return;
+
+        const url = new URL(window.location.href);
+        let onclick = "";
         if (article) {
-            const url = new URL(window.location.href);
             url.searchParams.set("article", article);
-            a.setAttribute("href", url.toString());
-            a.setAttribute("onclick", `toArticle('${article}'); return false;`);
+            onclick += `toArticle('${article}'); `;
         }
+        if (map) {
+            url.searchParams.set("map", map);
+            onclick += `toMap('${map}'); `;
+        }
+        onclick += "return false;";
+        a.setAttribute("href", url.toString());
+        a.setAttribute("onclick", onclick);
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,13 @@
 import { detectArticle, toArticle } from "./navigation/articles.js";
+import { detectMap, toMap } from "./navigation/maps.js";
 import { setAnchors } from "./components/anchor.js";
 import { TableOfContents } from "./components/table-of-contents.js";
 
-// This is to add the custom HTML elements to the document.
 customElements.define("table-of-contents", TableOfContents);
 
-// This is to allow HTML documents to call `toArticle`, since this is a module
-// type script we can't just do things like `onclick="toArticle('article')"`
-// because the script is deferred, so we put these functions on window where
-// they will be accessible to buttons.
 window.toArticle = toArticle;
+window.toMap = toMap;
 
-// These final lines are just the loading when the page loads the first time.
 detectArticle();
+detectMap();
 setAnchors();

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -1,0 +1,51 @@
+import { setAnchors } from "../components/anchor.js";
+import { changeSearchParam } from "./change-search-param.js";
+
+const imagesPath = "./assets/images/";
+
+// This one detects the article on the URL query strings and loads it
+export function detectMap() {
+    const container = document.getElementById("map-container");
+    const params = new URLSearchParams(window.location.search);
+    const query = params.get("map");
+
+    if (window.imports.maps[query]) {
+        const map = window.imports.maps[query];
+        const img = document.createElement("img");
+        img.src = imagesPath + map.image;
+        img.alt = map.name;
+        img.className = "h-full w-full absolute";
+        img.onload = () => {
+            const ratio = img.naturalWidth / img.naturalHeight;
+            document.body.style = `aspect-ratio: ${ratio}`;
+        };
+        container.appendChild(img);
+        map.links.forEach((link) => {
+            const a = document.createElement("a");
+            if (link.size === "large")
+                a.className = "text-5xl text-shadow font-fancy";
+            else if (link.size === "medium")
+                a.className = "text-3xl text-shadow font-fancy";
+            else if (link.size === "small")
+                a.className = "text-xl text-shadow-sm font-sans";
+            a.className +=
+                " font-bold absolute -translate-x-1/2 -translate-y-1/2";
+            if (link.toarticle) a.setAttribute("toarticle", link.toarticle);
+            if (link.tomap) a.setAttribute("tomap", link.tomap);
+            a.innerHTML = link.name;
+            a.style = `top: ${link.pos.y}; left: ${link.pos.x}; text-decoration: none;`;
+            container.appendChild(a);
+        });
+        return;
+    }
+
+    container.innerHTML = "";
+    changeSearchParam("map", "");
+}
+
+// This one changes the map on the URL query strings without reloading
+export function toMap(title) {
+    changeSearchParam("map", title);
+    detectMap();
+    setAnchors();
+}

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -53,3 +53,24 @@
         }
     }
 }
+
+.text-shadow {
+    text-shadow:
+        0.25rem 0.25rem 1rem rgba(0, 0, 0, 0.5),
+        -0.25rem 0.25rem 1rem rgba(0, 0, 0, 0.5),
+        0.25rem -0.25rem 1rem rgba(0, 0, 0, 0.5),
+        -0.25rem -0.25rem 1rem rgba(0, 0, 0, 0.5),
+        0.5rem 0.5rem 1rem rgba(0, 0, 0, 0.5),
+        -0.5rem 0.5rem 1rem rgba(0, 0, 0, 0.5),
+        0.5rem -0.5rem 1rem rgba(0, 0, 0, 0.5),
+        -0.5rem -0.5rem 1rem rgba(0, 0, 0, 0.5);
+}
+
+.text-shadow-sm {
+    text-shadow:
+        0.25rem 0.25rem 1rem black,
+        -0.25rem 0.25rem 1rem black,
+        0.25rem -0.25rem 1rem black,
+        -0.25rem -0.25rem 1rem black,
+        0 0 1rem black;
+}

--- a/tests/anchors-to-articles.test.js
+++ b/tests/anchors-to-articles.test.js
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
-import { moddedData as articles } from "./mocks/articles.js";
+import { moddedArticles as articles } from "./mocks/articles.js";
 
 describe("anchors to articles", () => {
     beforeEach(async () => {
         document.body.innerHTML = `
-            <div id="article-container"></div>
-            <a id="test" toarticle="article1"></a>"
-        `;
+                <div id="article-container"></div>
+                <div id="map-container"></div>
+                <a id="test" toarticle="article1"></a>
+            `;
         await import("./mocks/imports.js");
         await import("../src/main.js");
         document.getElementById("test").click();

--- a/tests/anchors-to-both-article-and-map.test.js
+++ b/tests/anchors-to-both-article-and-map.test.js
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { maps } from "./mocks/maps.js";
+
+describe("anchors to articles", () => {
+    beforeEach(async () => {
+        document.body.innerHTML = `
+                <div id="article-container"></div>
+                <div id="map-container"></div>
+                <a id="test" toarticle="article1" tomap="map1"></a>
+            `;
+        await import("./mocks/imports.js");
+        await import("../src/main.js");
+        document.getElementById("test").click();
+    });
+
+    test("should update search params and load map", () => {
+        const params = new URL(document.location.href).searchParams;
+        expect(params.get("article")).toBe("article1");
+        expect(params.get("map")).toBe("map1");
+        const articleContainer = document.getElementById("article-container");
+        // Can't use articles.article1 here because of the aditional map link
+        // after setAnchors.
+        expect(articleContainer.innerHTML).toBe(`
+        <h1>article1</h1>
+        <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map1" onclick="toArticle('article2'); return false;">article2</a> more content1</p>
+    `);
+        const map = maps["map1"];
+        const container = document.getElementById("map-container");
+        const children = container.getElementsByTagName("*");
+        expect(children[0].tagName).toBe("IMG");
+        expect(children[0].src).toBe(
+            "http://localhost/assets/images/" + map.image,
+        );
+        expect(children[0].alt).toBe(map.name);
+        expect(children[1].tagName).toBe("A");
+        expect(children[1].getAttribute("toarticle")).toBe(
+            map.links[0].toarticle,
+        );
+        expect(children[1].innerHTML).toBe(map.links[0].name);
+        expect(children[2].tagName).toBe("A");
+        expect(children[2].getAttribute("tomap")).toBe(map.links[1].tomap);
+        expect(children[2].innerHTML).toBe(map.links[1].name);
+        expect(children[3].tagName).toBe("A");
+        expect(children[3].getAttribute("toarticle")).toBe(
+            map.links[2].toarticle,
+        );
+        expect(children[2].getAttribute("tomap")).toBe(map.links[1].tomap);
+        expect(children[3].innerHTML).toBe(map.links[2].name);
+    });
+});

--- a/tests/anchors-to-maps.test.js
+++ b/tests/anchors-to-maps.test.js
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { maps } from "./mocks/maps.js";
+
+describe("anchors to articles", () => {
+    beforeEach(async () => {
+        document.body.innerHTML = `
+                <div id="article-container"></div>
+                <div id="map-container"></div>
+                <a id="test" tomap="map1"></a>
+            `;
+        await import("./mocks/imports.js");
+        await import("../src/main.js");
+        document.getElementById("test").click();
+    });
+
+    test("should update search params and load map", () => {
+        const map = maps["map1"];
+        const params = new URL(document.location.href).searchParams;
+        expect(params.get("map")).toBe("map1");
+        const container = document.getElementById("map-container");
+        const children = container.getElementsByTagName("*");
+        expect(children[0].tagName).toBe("IMG");
+        expect(children[0].src).toBe(
+            "http://localhost/assets/images/" + map.image,
+        );
+        expect(children[0].alt).toBe(map.name);
+        expect(children[1].tagName).toBe("A");
+        expect(children[1].getAttribute("toarticle")).toBe(
+            map.links[0].toarticle,
+        );
+        expect(children[1].innerHTML).toBe(map.links[0].name);
+        expect(children[2].tagName).toBe("A");
+        expect(children[2].getAttribute("tomap")).toBe(map.links[1].tomap);
+        expect(children[2].innerHTML).toBe(map.links[1].name);
+        expect(children[3].tagName).toBe("A");
+        expect(children[3].getAttribute("toarticle")).toBe(
+            map.links[2].toarticle,
+        );
+        expect(children[2].getAttribute("tomap")).toBe(map.links[2].tomap);
+        expect(children[3].innerHTML).toBe(map.links[2].name);
+    });
+});

--- a/tests/article-on-load.test.js
+++ b/tests/article-on-load.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { changeSearchParam } from "../src/navigation/change-search-param.js";
-import { moddedData as articles } from "./mocks/articles.js";
+import { moddedArticles as articles } from "./mocks/articles.js";
 import fs from "fs";
 
 describe("article on load", () => {

--- a/tests/articles-anchor-links.test.js
+++ b/tests/articles-anchor-links.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import articles from "../build/articles.js";
+import maps from "../build/maps.js";
 
 describe("articles anchor links", () => {
     const scenarios = Object.entries(articles).map((entry) => ({
@@ -12,9 +13,13 @@ describe("articles anchor links", () => {
         const anchors = document.querySelectorAll("a");
         const badLinks = [];
         anchors.forEach((a) => {
-            const target = a.getAttribute("toarticle");
-            if (!Object.hasOwn(articles, target)) {
-                badLinks.push(target);
+            const targetArticle = a.getAttribute("toarticle");
+            if (targetArticle && !Object.hasOwn(articles, targetArticle)) {
+                badLinks.push(targetArticle);
+            }
+            const targetMap = a.getAttribute("tomap");
+            if (targetMap && !Object.hasOwn(maps, targetMap)) {
+                badLinks.push(targetMap);
             }
         });
 

--- a/tests/build-maps.test.js
+++ b/tests/build-maps.test.js
@@ -80,7 +80,7 @@ describe("buildMaps", () => {
         let expectedData = "";
 
         beforeEach(() => {
-            readFileSyncSpy.mockReturnValue("");
+            readFileSyncSpy.mockReturnValue("{}");
             readdirSyncSpy.mockReturnValue([
                 "file.json",
                 "nope.txt",
@@ -91,7 +91,7 @@ describe("buildMaps", () => {
                 result.data = data;
             });
             expectedData =
-                "export default " + JSON.stringify({ file: "", other: "" });
+                "export default " + JSON.stringify({ file: {}, other: {} });
             buildMaps(mapsPath, buildPath);
         });
 

--- a/tests/map-on-load.test.js
+++ b/tests/map-on-load.test.js
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { changeSearchParam } from "../src/navigation/change-search-param.js";
+import { maps } from "./mocks/maps.js";
+import fs from "fs";
+
+describe("map on load", () => {
+    beforeEach(async () => {
+        document.body.innerHTML = fs.readFileSync("./index.html", {
+            encoding: "utf8",
+        });
+        changeSearchParam("map", "map1");
+        await import("./mocks/imports.js");
+        await import("../src/main.js");
+    });
+
+    test("should load map on start", () => {
+        const map = maps["map1"];
+        const params = new URL(document.location.href).searchParams;
+        expect(params.get("map")).toBe("map1");
+        const container = document.getElementById("map-container");
+        const children = container.getElementsByTagName("*");
+        expect(children[0].tagName).toBe("IMG");
+        expect(children[0].src).toBe(
+            "http://localhost/assets/images/" + map.image,
+        );
+        expect(children[0].alt).toBe(map.name);
+        expect(children[1].tagName).toBe("A");
+        expect(children[1].getAttribute("toarticle")).toBe(
+            map.links[0].toarticle,
+        );
+        expect(children[1].innerHTML).toBe(map.links[0].name);
+        expect(children[2].tagName).toBe("A");
+        expect(children[2].getAttribute("tomap")).toBe(map.links[1].tomap);
+        expect(children[2].innerHTML).toBe(map.links[1].name);
+        expect(children[3].tagName).toBe("A");
+        expect(children[3].getAttribute("toarticle")).toBe(
+            map.links[2].toarticle,
+        );
+        expect(children[2].getAttribute("tomap")).toBe(map.links[2].tomap);
+        expect(children[3].innerHTML).toBe(map.links[2].name);
+    });
+});

--- a/tests/maps-anchor-links.test.js
+++ b/tests/maps-anchor-links.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "@jest/globals";
+import maps from "../build/maps.js";
+import articles from "../build/articles.js";
+
+describe("maps anchor links", () => {
+    const scenarios = Object.entries(maps).map((entry) => ({
+        name: entry[0],
+        table: entry[1],
+    }));
+
+    describe.each(scenarios)("$name", ({ table }) => {
+        test("should have name, image and links", () => {
+            expect(table).toHaveProperty("name");
+            expect(table).toHaveProperty("image");
+            expect(table).toHaveProperty("links");
+        });
+
+        const linksWithoutName = [];
+        const linksWithoutSize = [];
+        const linksWithBadSize = [];
+        const linksWithoutPos = [];
+        const linksWithBadPos = [];
+        const linksWithBrokenToArticle = [];
+        const linksWithBrokenToMap = [];
+        table.links.forEach((link) => {
+            if (!link.name) linksWithoutName.push("link with no name");
+            if (!link.size) linksWithoutSize.push(link.name);
+            else if (
+                link.size != "large" &&
+                link.size != "medium" &&
+                link.size != "small"
+            )
+                linksWithBadSize.push(link.name);
+            if (!link.pos) linksWithoutPos.push(link.name);
+            else if (!link.pos.x || !link.pos.y)
+                linksWithBadPos.push(link.name);
+            if (link.toarticle && !Object.hasOwn(articles, link.toarticle))
+                linksWithBrokenToArticle.push(link.name);
+            if (link.tomap && !Object.hasOwn(maps, link.tomap))
+                linksWithBrokenToMap.push(link.name);
+        });
+
+        test("links should have name", () => {
+            expect(linksWithoutName).toStrictEqual([]);
+        });
+
+        test("links should have a valid size", () => {
+            expect(linksWithoutSize).toStrictEqual([]);
+            expect(linksWithBadSize).toStrictEqual([]);
+        });
+
+        test("links should have a valid pos", () => {
+            expect(linksWithoutPos).toStrictEqual([]);
+            expect(linksWithBadPos).toStrictEqual([]);
+        });
+
+        test("links should not have broken toarticle", () => {
+            expect(linksWithBrokenToArticle).toStrictEqual([]);
+        });
+
+        test("links should not have broken tomap", () => {
+            expect(linksWithBrokenToMap).toStrictEqual([]);
+        });
+    });
+});

--- a/tests/mocks/articles.js
+++ b/tests/mocks/articles.js
@@ -1,21 +1,21 @@
-export const data = {
+export const articles = {
     article1: `
         <h1>article1</h1>
         <p>content <a toarticle="article2">article2</a> more content1</p>
     `,
     article2: `
-        <h1>aritlce2</h1>
+        <h1>article2</h1>
         <p>content <a toarticle="article1">article1</a> more content2</p>
     `,
 };
 
-export const moddedData = {
+export const moddedArticles = {
     article1: `
         <h1>article1</h1>
         <p>content <a toarticle="article2" href="http://localhost/?article=article2" onclick="toArticle('article2'); return false;">article2</a> more content1</p>
     `,
     article2: `
-        <h1>aritlce2</h1>
+        <h1>article2</h1>
         <p>content <a toarticle="article1" href="http://localhost/?article=article1" onclick="toArticle('article1'); return false;">article1</a> more content2</p>
     `,
 };

--- a/tests/mocks/imports.js
+++ b/tests/mocks/imports.js
@@ -1,3 +1,4 @@
-import { data } from "./articles.js";
+import { articles } from "./articles.js";
+import { maps } from "./maps.js";
 
-window.imports = { articles: data };
+window.imports = { articles, maps };

--- a/tests/mocks/maps.js
+++ b/tests/mocks/maps.js
@@ -1,0 +1,36 @@
+export const maps = {
+    map1: {
+        name: "mockmap1",
+        image: "mockimage1.png",
+        links: [
+            {
+                name: "mocklink1",
+                size: "large",
+                toarticle: "mockarticle",
+                pos: {
+                    x: "10%",
+                    y: "80%",
+                },
+            },
+            {
+                name: "mocklink2",
+                size: "medium",
+                tomap: "mockmap",
+                pos: {
+                    x: "40%",
+                    y: "60%",
+                },
+            },
+            {
+                name: "mocklink3",
+                size: "small",
+                toarticle: "mockarticle",
+                tomap: "mockmap",
+                pos: {
+                    x: "70%",
+                    y: "40%",
+                },
+            },
+        ],
+    },
+};

--- a/tests/table-of-contents.test.js
+++ b/tests/table-of-contents.test.js
@@ -4,6 +4,7 @@ describe("table of contents", () => {
     beforeEach(async () => {
         document.body.innerHTML = `
             <div id="article-container"></div>
+            <div id="map-container"></div>
             <h2>Don't search this one</h1>
             <div>
                 <h1>Article title</h1>


### PR DESCRIPTION
Makes maps load and allows for navigating through maps from anchors just like we do with articles.

This commit also tweaks the map build in order to accommodate for necessary unforeseen things, but nothing too deep.

Also updates old tests and make new ones for the maps.