### PR TITLE
Implement project settings

### DIFF
--- a/bin/build-settings
+++ b/bin/build-settings
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { buildSettings } from "../scripts/build-settings.js";
+
+buildSettings("project-settings.json", "build/settings.js");

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "build:tailwindcss": "npx tailwindcss -i ./src/stylesheet.css -o ./build/stylesheet.css --minify",
         "build:articles": "./bin/build-articles",
         "build:maps": "./bin/build-maps",
-        "build": "rm -rf build/ && mkdir build && npm run build:tailwindcss && npm run build:articles && npm run build:maps",
+        "build:settings": "./bin/build-settings",
+        "build": "rm -rf build/ && mkdir build && npm run build:tailwindcss && npm run build:articles && npm run build:maps && npm run build:settings",
         "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
     },
     "devDependencies": {

--- a/project-settings.json
+++ b/project-settings.json
@@ -1,0 +1,7 @@
+{
+    "defaultMap": "map1",
+    "labels": {
+        "closeArticle": "Close",
+        "tableOfContents": "Table of Contents"
+    }
+}

--- a/scripts/build-settings.js
+++ b/scripts/build-settings.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import process from "process";
+
+function readProjectSettings(settingsPath) {
+    return JSON.parse(fs.readFileSync(settingsPath), { encoding: "utf8" });
+}
+
+export function buildSettings(settingsPath, buildPath) {
+    process.stdout.write("Building settings...");
+    try {
+        const settings = readProjectSettings(settingsPath);
+        const data = "export default " + JSON.stringify(settings);
+        fs.writeFileSync(buildPath, data);
+        process.stdout.write("\x1b[32m Success \x1b[0m \n");
+        process.exit(0);
+    } catch (error) {
+        process.stdout.write("\x1b[31m Failed \x1b[0m \n\n");
+        console.error(error); // eslint-disable-line
+        process.exit(1);
+    }
+}

--- a/src/imports.js
+++ b/src/imports.js
@@ -1,4 +1,5 @@
 import articles from "../build/articles.js";
 import maps from "../build/maps.js";
+import settings from "../build/settings.js";
 
-window.imports = { articles, maps };
+window.imports = { articles, maps, settings };

--- a/tests/build-settings.test.js
+++ b/tests/build-settings.test.js
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from "fs";
+import process from "process";
+import { jest, describe, beforeEach, expect, test } from "@jest/globals";
+import { buildSettings } from "../scripts/build-settings.js";
+
+const settingsPath = "somedir/";
+const buildPath = "mock/file.js";
+
+const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
+
+const writeSpy = jest
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => {});
+const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+describe("buildSettings", () => {
+    describe("when readFileSync throws an error", () => {
+        beforeEach(() => {
+            readFileSyncSpy.mockImplementation(() => {
+                throw "mock error";
+            });
+            writeFileSyncSpy.mockImplementation(() => {});
+            buildSettings(settingsPath, buildPath);
+        });
+
+        test("should not write data to any file", () => {
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+        });
+
+        test("should log the process correctly", () => {
+            expect(writeSpy).toHaveBeenCalledWith("Building settings...");
+            expect(writeSpy).toHaveBeenCalledWith(
+                "\x1b[31m Failed \x1b[0m \n\n",
+            );
+            expect(errorSpy).toHaveBeenCalled();
+        });
+
+        test("should exit with errors", () => {
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+    });
+
+    describe("when successful", () => {
+        let result = { path: "", data: "" };
+        let expectedData = "";
+
+        beforeEach(() => {
+            readFileSyncSpy.mockReturnValue("{}");
+            writeFileSyncSpy.mockImplementation((path, data) => {
+                result.path = path;
+                result.data = data;
+            });
+            expectedData = "export default " + JSON.stringify({});
+            buildSettings(settingsPath, buildPath);
+        });
+
+        test("should generate data correctly", () => {
+            expect(result.data).toBe(expectedData);
+        });
+
+        test("should write data to the target file", () => {
+            expect(result.path).toBe(buildPath);
+        });
+
+        test("should log the process correctly", () => {
+            expect(writeSpy).toHaveBeenCalledWith("Building settings...");
+            expect(writeSpy).toHaveBeenCalledWith(
+                "\x1b[32m Success \x1b[0m \n",
+            );
+        });
+
+        test("should exit with no errors", () => {
+            expect(exitSpy).toHaveBeenCalledWith(0);
+        });
+    });
+});


### PR DESCRIPTION
A JSON file for settings, to make it easier to change very specific things such as labels and defaults that should vary from fork to fork.

The inspiration behind this feature came because I wanted to implement a default map, so that if you opened that link with no map search param it would load a default map always, and whenever you input an invalid map or an empty map, it would send you to this map and erase the search param. It's obvious that such default map needed a way to change it more easily, especially for non technical DMs forking this. I was also already thinking about localization on the table of contents label, and now with the "close" label on the top of the articles container, this settings feature should also take care of it.