### PR TITLE
Implement default map feature

### DIFF
--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -3,39 +3,51 @@ import { changeSearchParam } from "./change-search-param.js";
 
 const imagesPath = "./assets/images/";
 
+function loadMap(data) {
+    const container = document.getElementById("map-container");
+    container.innerHTML = "";
+    const img = document.createElement("img");
+    img.src = imagesPath + data.image;
+    img.alt = data.name;
+    img.className = "h-full w-full absolute";
+    img.onload = () => {
+        const ratio = img.naturalWidth / img.naturalHeight;
+        document.body.style = `aspect-ratio: ${ratio}`;
+    };
+    container.appendChild(img);
+    data.links.forEach((link) => {
+        const a = document.createElement("a");
+        if (link.size === "large") a.className = "map-large";
+        else if (link.size === "medium") a.className = "map-medium";
+        else if (link.size === "small") a.className = "map-small";
+        if (link.toarticle) a.setAttribute("toarticle", link.toarticle);
+        if (link.tomap) a.setAttribute("tomap", link.tomap);
+        a.innerHTML = link.name;
+        a.style = `top: ${link.pos.y}; left: ${link.pos.x};`;
+        container.appendChild(a);
+    });
+}
+
 // This one detects the article on the URL query strings and loads it
 export function detectMap() {
-    const container = document.getElementById("map-container");
     const params = new URLSearchParams(window.location.search);
     const query = params.get("map");
 
-    if (window.imports.maps[query]) {
-        const map = window.imports.maps[query];
-        const img = document.createElement("img");
-        img.src = imagesPath + map.image;
-        img.alt = map.name;
-        img.className = "h-full w-full absolute";
-        img.onload = () => {
-            const ratio = img.naturalWidth / img.naturalHeight;
-            document.body.style = `aspect-ratio: ${ratio}`;
-        };
-        container.appendChild(img);
-        map.links.forEach((link) => {
-            const a = document.createElement("a");
-            if (link.size === "large") a.className = "map-large";
-            else if (link.size === "medium") a.className = "map-medium";
-            else if (link.size === "small") a.className = "map-small";
-            if (link.toarticle) a.setAttribute("toarticle", link.toarticle);
-            if (link.tomap) a.setAttribute("tomap", link.tomap);
-            a.innerHTML = link.name;
-            a.style = `top: ${link.pos.y}; left: ${link.pos.x};`;
-            container.appendChild(a);
-        });
+    if (query === window.imports.settings.defaultMap) {
+        changeSearchParam("map", "");
+        const defaultMap = window.imports.settings.defaultMap;
+        loadMap(window.imports.maps[defaultMap]);
         return;
     }
 
-    container.innerHTML = "";
+    if (window.imports.maps[query]) {
+        loadMap(window.imports.maps[query]);
+        return;
+    }
+
     changeSearchParam("map", "");
+    const defaultMap = window.imports.settings.defaultMap;
+    loadMap(window.imports.maps[defaultMap]);
 }
 
 // This one changes the map on the URL query strings without reloading

--- a/tests/anchors-to-maps.test.js
+++ b/tests/anchors-to-maps.test.js
@@ -7,7 +7,7 @@ describe("anchors to articles", () => {
                 <div id="article-container-inner"></div>
                 <div id="article-container-outer"></div>
                 <div id="map-container"></div>
-                <a id="test" tomap="map1"></a>
+                <a id="test" tomap="map2"></a>
             `;
         await import("./mocks/imports.js");
         await import("../src/main.js");
@@ -15,9 +15,9 @@ describe("anchors to articles", () => {
     });
 
     test("should update search params and load map", () => {
-        const map = maps["map1"];
+        const map = maps["map2"];
         const params = new URL(document.location.href).searchParams;
-        expect(params.get("map")).toBe("map1");
+        expect(params.get("map")).toBe("map2");
         const container = document.getElementById("map-container");
         const children = container.getElementsByTagName("*");
         expect(children[0].tagName).toBe("IMG");

--- a/tests/anchors-to-no-map.test.js
+++ b/tests/anchors-to-no-map.test.js
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { maps } from "./mocks/maps.js";
+import { settings } from "./mocks/settings.js";
+import { changeSearchParam } from "../src/navigation/change-search-param.js";
 
 describe("anchors to articles", () => {
     beforeEach(async () => {
@@ -7,27 +9,18 @@ describe("anchors to articles", () => {
                 <div id="article-container-inner"></div>
                 <div id="article-container-outer"></div>
                 <div id="map-container"></div>
-                <a id="test" toarticle="article1" tomap="map2"></a>
+                <a id="test" tomap=""></a>
             `;
+        changeSearchParam("map", "map2");
         await import("./mocks/imports.js");
         await import("../src/main.js");
         document.getElementById("test").click();
     });
 
     test("should update search params and load map", () => {
+        const map = maps[settings.defaultMap];
         const params = new URL(document.location.href).searchParams;
-        expect(params.get("article")).toBe("article1");
-        expect(params.get("map")).toBe("map2");
-        const inner = document.getElementById("article-container-inner");
-        const outer = document.getElementById("article-container-outer");
-        // Can't use articles.article1 here because of the aditional map link
-        // after setAnchors.
-        expect(outer.getAttribute("data-hidden")).toBe("false");
-        expect(inner.innerHTML).toBe(`
-        <h1>article1</h1>
-        <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map2" onclick="toArticle('article2'); return false;">article2</a> more content1</p>
-    `);
-        const map = maps["map2"];
+        expect(params.get("map")).toBeNull();
         const container = document.getElementById("map-container");
         const children = container.getElementsByTagName("*");
         expect(children[0].tagName).toBe("IMG");
@@ -47,7 +40,7 @@ describe("anchors to articles", () => {
         expect(children[3].getAttribute("toarticle")).toBe(
             map.links[2].toarticle,
         );
-        expect(children[2].getAttribute("tomap")).toBe(map.links[1].tomap);
+        expect(children[2].getAttribute("tomap")).toBe(map.links[2].tomap);
         expect(children[3].innerHTML).toBe(map.links[2].name);
     });
 });

--- a/tests/map-on-load.test.js
+++ b/tests/map-on-load.test.js
@@ -8,15 +8,15 @@ describe("map on load", () => {
         document.body.innerHTML = fs.readFileSync("./index.html", {
             encoding: "utf8",
         });
-        changeSearchParam("map", "map1");
+        changeSearchParam("map", "map2");
         await import("./mocks/imports.js");
         await import("../src/main.js");
     });
 
     test("should load map on start", () => {
-        const map = maps["map1"];
+        const map = maps["map2"];
         const params = new URL(document.location.href).searchParams;
-        expect(params.get("map")).toBe("map1");
+        expect(params.get("map")).toBe("map2");
         const container = document.getElementById("map-container");
         const children = container.getElementsByTagName("*");
         expect(children[0].tagName).toBe("IMG");

--- a/tests/mocks/imports.js
+++ b/tests/mocks/imports.js
@@ -1,4 +1,5 @@
 import { articles } from "./articles.js";
 import { maps } from "./maps.js";
+import { settings } from "./settings.js";
 
-window.imports = { articles, maps };
+window.imports = { articles, maps, settings };

--- a/tests/mocks/maps.js
+++ b/tests/mocks/maps.js
@@ -33,4 +33,38 @@ export const maps = {
             },
         ],
     },
+    map2: {
+        name: "mockmap2",
+        image: "mockimage2.png",
+        links: [
+            {
+                name: "mocklink1",
+                size: "large",
+                toarticle: "mockarticle",
+                pos: {
+                    x: "10%",
+                    y: "80%",
+                },
+            },
+            {
+                name: "mocklink2",
+                size: "medium",
+                tomap: "mockmap",
+                pos: {
+                    x: "40%",
+                    y: "60%",
+                },
+            },
+            {
+                name: "mocklink3",
+                size: "small",
+                toarticle: "mockarticle",
+                tomap: "mockmap",
+                pos: {
+                    x: "70%",
+                    y: "40%",
+                },
+            },
+        ],
+    },
 };

--- a/tests/mocks/settings.js
+++ b/tests/mocks/settings.js
@@ -1,0 +1,7 @@
+export const settings = {
+    defaultMap: "map1",
+    labels: {
+        closeArticle: "Close",
+        tableOfContents: "Table of Contents",
+    },
+};

--- a/tests/table-of-contents.test.js
+++ b/tests/table-of-contents.test.js
@@ -6,19 +6,21 @@ describe("table of contents", () => {
             <div id="article-container-inner"></div>
             <div id="article-container-outer"></div>
             <div id="map-container"></div>
-            <h2>Don't search this one</h1>
-            <div>
-                <h1>Article title</h1>
-                <p>some text for the intro</p>
-                <table-of-contents></table-of-contents>
-                <h2 id="first-section">First section</h2>
-                <p>more text</p>
-                <h3 id="some-subsection">Subsection</h3>
-                <h4>Subsubsection</h4>
-                <h5>Don't care at this point</h5>
-                <h6>sure yes</h6>
-                <h1 id="whynot">Why not</h1>
-                <h2 id="tests">tests</h2>
+            <div id="test">
+                <h2>Don't search this one</h2>
+                <div>
+                    <h1>Article title</h1>
+                    <p>some text for the intro</p>
+                    <table-of-contents></table-of-contents>
+                    <h2 id="first-section">First section</h2>
+                    <p>more text</p>
+                    <h3 id="some-subsection">Subsection</h3>
+                    <h4>Subsubsection</h4>
+                    <h5>Don't care at this point</h5>
+                    <h6>sure yes</h6>
+                    <h1 id="whynot">Why not</h1>
+                    <h2 id="tests">tests</h2>
+                </div>
             </div>
         `;
         await import("./mocks/imports.js");
@@ -26,7 +28,7 @@ describe("table of contents", () => {
     });
 
     test("Should search for headers and create links correctly", () => {
-        const anchors = document.querySelectorAll("a");
+        const anchors = document.getElementById("test").querySelectorAll("a");
         expect(anchors.length).toBe(6);
         expect(anchors[0].href).toBe("http://localhost/#first-section");
         expect(anchors[0].innerHTML).toBe("First section");


### PR DESCRIPTION
Now, when there is no map on the search params, it loads a default map set by `project-settings.json`. If you link to it, the search params will detect it and clean it up, as it's the default.