### PR TITLE
Implement browser back function

### DIFF
--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -1,3 +1,7 @@
+import { changeSearchParam } from "../navigation/change-search-param.js";
+import { detectArticle } from "../navigation/articles.js";
+import { detectMap } from "../navigation/maps.js";
+
 // This is to override the default behavior of anchors (<a></a> tags). We want
 // them to not reload the page, just change search params and re-render. This
 // function scans for anchors and does that. We're using the custom attributes
@@ -9,20 +13,27 @@ export function setAnchors() {
     anchors.forEach((a) => {
         if (!a.hasAttribute("toarticle") && !a.hasAttribute("tomap")) return;
 
+        const newState = {};
         const url = new URL(window.location.href);
-        let onclick = "";
+        url.hash = "";
         if (a.hasAttribute("toarticle")) {
             const article = a.getAttribute("toarticle");
+            newState.article = article;
             url.searchParams.set("article", article);
-            onclick += `toArticle('${article}'); `;
         }
         if (a.hasAttribute("tomap")) {
             const map = a.getAttribute("tomap");
+            newState.map = map;
             url.searchParams.set("map", map);
-            onclick += `toMap('${map}'); `;
         }
-        onclick += "return false;";
+
         a.setAttribute("href", url.toString());
-        a.setAttribute("onclick", onclick);
+        a.onclick = () => {
+            changeSearchParam(newState);
+            if ("article" in newState) detectArticle();
+            if ("map" in newState) detectMap();
+            setAnchors();
+            return false;
+        };
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,19 @@
-import { detectArticle, toArticle } from "./navigation/articles.js";
-import { detectMap, toMap } from "./navigation/maps.js";
+import { detectArticle } from "./navigation/articles.js";
+import { detectMap } from "./navigation/maps.js";
 import { setAnchors } from "./components/anchor.js";
 import { TableOfContents } from "./components/table-of-contents.js";
 import { detectTheme } from "./components/theme-switcher.js";
 
 customElements.define("table-of-contents", TableOfContents);
 
-window.toArticle = toArticle;
-window.toMap = toMap;
-
 document.getElementById("close-article-btn").innerHTML =
     window.imports.settings.labels.closeArticle;
+
+addEventListener("popstate", () => {
+    detectArticle();
+    detectMap();
+    setAnchors();
+});
 
 detectTheme();
 detectArticle();

--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -1,7 +1,5 @@
-import { setAnchors } from "../components/anchor.js";
 import { changeSearchParam } from "./change-search-param.js";
 
-// This one detects the article on the URL query strings and loads it
 export function detectArticle() {
     const outer = document.getElementById("article-container-outer");
     const inner = document.getElementById("article-container-inner");
@@ -16,12 +14,5 @@ export function detectArticle() {
 
     outer.setAttribute("data-hidden", true);
     inner.innerHTML = "";
-    changeSearchParam("article", "");
-}
-
-// This one changes the article on the URL query strings without reloading
-export function toArticle(title) {
-    changeSearchParam("article", title);
-    detectArticle();
-    setAnchors();
+    changeSearchParam({ article: "" });
 }

--- a/src/navigation/change-search-param.js
+++ b/src/navigation/change-search-param.js
@@ -1,9 +1,11 @@
-export function changeSearchParam(param, value) {
+export function changeSearchParam(state) {
     const url = new URL(document.location.href);
-    if (value) {
-        url.searchParams.set(param, value);
-    } else {
-        url.searchParams.delete(param);
-    }
-    window.history.pushState(null, "", url.toString());
+    Object.keys(state).forEach((key) => {
+        if (state[key]) {
+            url.searchParams.set(key, state[key]);
+        } else {
+            url.searchParams.delete(key);
+        }
+    });
+    window.history.pushState({}, "", url.toString());
 }

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -1,4 +1,3 @@
-import { setAnchors } from "../components/anchor.js";
 import { changeSearchParam } from "./change-search-param.js";
 
 const imagesPath = "./assets/images/";
@@ -34,7 +33,6 @@ function loadMap(data) {
     });
 }
 
-// This one detects the article on the URL query strings and loads it
 export function detectMap() {
     const params = new URLSearchParams(window.location.search);
     const query = params.get("map");
@@ -51,14 +49,7 @@ export function detectMap() {
         return;
     }
 
-    changeSearchParam("map", "");
+    changeSearchParam({ map: "" });
     const defaultMap = window.imports.settings.defaultMap;
     loadMap(window.imports.maps[defaultMap]);
-}
-
-// This one changes the map on the URL query strings without reloading
-export function toMap(title) {
-    changeSearchParam("map", title);
-    detectMap();
-    setAnchors();
 }

--- a/tests/anchors-to-both-article-and-map.test.js
+++ b/tests/anchors-to-both-article-and-map.test.js
@@ -18,7 +18,7 @@ describe("anchors to articles", () => {
         // link after setAnchors.
         const moddedArticle = `
         <h1>article1</h1>
-        <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map2" onclick="toArticle('article2'); return false;">article2</a> more content1</p>
+        <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map2">article2</a> more content1</p>
     `;
         expect(isArticleLoaded("article1", moddedArticle)).toBe(true);
         expect(isMapLoaded("map2", maps["map2"])).toBe(true);

--- a/tests/mocks/articles.js
+++ b/tests/mocks/articles.js
@@ -12,10 +12,10 @@ export const articles = {
 export const moddedArticles = {
     article1: `
         <h1>article1</h1>
-        <p>content <a toarticle="article2" href="http://localhost/?article=article2" onclick="toArticle('article2'); return false;">article2</a> more content1</p>
+        <p>content <a toarticle="article2" href="http://localhost/?article=article2">article2</a> more content1</p>
     `,
     article2: `
         <h1>article2</h1>
-        <p>content <a toarticle="article1" href="http://localhost/?article=article1" onclick="toArticle('article1'); return false;">article1</a> more content2</p>
+        <p>content <a toarticle="article1" href="http://localhost/?article=article1">article1</a> more content2</p>
     `,
 };

--- a/tests/utils/init-dom.js
+++ b/tests/utils/init-dom.js
@@ -20,9 +20,7 @@ export async function initDom(additionalElements = [], searchParams = {}) {
     additionalElements.forEach((element) => {
         document.body.appendChild(element);
     });
-    Object.entries(searchParams).forEach((entry) => {
-        changeSearchParam(entry[0], entry[1]);
-    });
+    changeSearchParam(searchParams);
 
     // Load the scripts. Keep in mind <script> tags don't work on JSDOM,
     // so we load scripts directly which works in the same way because


### PR DESCRIPTION
Because of the way we navigate without reloading the page but pushing to history, pressing the back button causes the URL to return to what it was previously but the page wouldn't update because we wouldn't call the detect functions.

This commit fixes it with the `popstate` event. We also improved and cleaned up a little more of the previous code revolving navigation, like the old `toArticle()` and `toMap()` functions, that were created mostly to allow buttons to navigate but in the end only using anchors to navigate because it makes more sense on a web app, also because when you hover the mouse on an anchor it shows where it's going to take you while buttons can't do that cleanly. So if we're just using anchors for that, there's no need to have these functions existing.