### PR TITLE
Fix anchor hrefs

### DIFF
--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -19,19 +19,28 @@ export function setAnchors() {
         if (a.hasAttribute("toarticle")) {
             const article = a.getAttribute("toarticle");
             newState.article = article;
-            url.searchParams.set("article", article);
+            if (article === "") {
+                url.searchParams.delete("article");
+            } else {
+                url.searchParams.set("article", article);
+            }
         }
         if (a.hasAttribute("tomap")) {
             const map = a.getAttribute("tomap");
-            newState.map = map;
-            url.searchParams.set("map", map);
+            if (map === window.imports.settings.defaultMap || map === "") {
+                newState.map = "";
+                url.searchParams.delete("map");
+            } else {
+                newState.map = map;
+                url.searchParams.set("map", map);
+            }
         }
 
         a.setAttribute("href", url.toString());
         a.onclick = () => {
             changeSearchParam(newState);
-            if ("article" in newState) detectArticle();
-            if ("map" in newState) detectMap();
+            detectArticle();
+            detectMap();
             setAnchors();
             return false;
         };

--- a/tests/anchor-hrefs.test.js
+++ b/tests/anchor-hrefs.test.js
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+
+describe("anchor hrefs", () => {
+    const anchors = [];
+
+    beforeEach(async () => {
+        anchors.push(document.createElement("a"));
+        anchors[0].setAttribute("toarticle", "article2");
+        anchors.push(document.createElement("a"));
+        anchors[1].setAttribute("tomap", "map2");
+        anchors.push(document.createElement("a"));
+        anchors[2].setAttribute("toarticle", "");
+        anchors[2].setAttribute("tomap", "map1");
+        anchors.push(document.createElement("a"));
+        anchors[3].setAttribute("toarticle", "article2");
+        anchors[3].setAttribute("tomap", "");
+        anchors.push(document.createElement("a"));
+        anchors[4].setAttribute("toarticle", "");
+        anchors[4].setAttribute("tomap", "");
+        await initDom(anchors, { article: "article1", map: "map2" });
+    });
+
+    test("should have correct hrefs", () => {
+        expect(anchors[0].href).toBe(
+            "http://localhost/?article=article2&map=map2",
+        );
+        expect(anchors[1].href).toBe(
+            "http://localhost/?article=article1&map=map2",
+        );
+        expect(anchors[2].href).toBe("http://localhost/");
+        expect(anchors[3].href).toBe("http://localhost/?article=article2");
+        expect(anchors[4].href).toBe("http://localhost/");
+    });
+});


### PR DESCRIPTION
Anchors with `""` on `tomap` or `toarticle` has broken hrefs. They worked and sent you to the right place though.

Also changes the way `tomap` works when sending you to the default map, now an anchor to the default map just deletes the `map` search param in the same way a link with `tomap=""` would.