### PR TITLE
Update table of contents

### DIFF
--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -4,8 +4,7 @@ export class TableOfContents extends HTMLElement {
     }
 
     connectedCallback() {
-        const headers =
-            this.parentElement.querySelectorAll("h2, h3, h4, h5, h6");
+        const headers = this.parentElement.querySelectorAll("h2, h3, h4");
         const tocHeader = document.createElement("h3");
         tocHeader.innerHTML = window.imports.settings.labels.tableOfContents;
         this.appendChild(tocHeader);
@@ -22,10 +21,6 @@ export class TableOfContents extends HTMLElement {
                 a.className = "font-sans ml-4";
             } else if (header.tagName === "H4") {
                 a.className = "font-sans ml-8";
-            } else if (header.tagName === "H5") {
-                a.className = "font-sans ml-12";
-            } else if (header.tagName === "H6") {
-                a.className = "font-sans ml-16";
             }
             li.appendChild(a);
             list.appendChild(li);

--- a/tests/table-of-contents.test.js
+++ b/tests/table-of-contents.test.js
@@ -26,18 +26,14 @@ describe("table of contents", () => {
 
     test("Should search for headers and create links correctly", () => {
         const anchors = document.getElementById("test").querySelectorAll("a");
-        expect(anchors.length).toBe(6);
+        expect(anchors.length).toBe(4);
         expect(anchors[0].href).toBe("http://localhost/#first-section");
         expect(anchors[0].innerHTML).toBe("First section");
         expect(anchors[1].href).toBe("http://localhost/#some-subsection");
         expect(anchors[1].innerHTML).toBe("Subsection");
         expect(anchors[2].href).toBe("http://localhost/#0");
         expect(anchors[2].innerHTML).toBe("Subsubsection");
-        expect(anchors[3].href).toBe("http://localhost/#1");
-        expect(anchors[3].innerHTML).toBe("Don't care at this point");
-        expect(anchors[4].href).toBe("http://localhost/#2");
-        expect(anchors[4].innerHTML).toBe("sure yes");
-        expect(anchors[5].href).toBe("http://localhost/#tests");
-        expect(anchors[5].innerHTML).toBe("tests");
+        expect(anchors[3].href).toBe("http://localhost/#tests");
+        expect(anchors[3].innerHTML).toBe("tests");
     });
 });


### PR DESCRIPTION
We shouldn't link to h5 and h6 elements, we should have at least one option of minor header to subsect text without having it added to the table of contents, so we're using h5 and h6 for this.