### PR TITLE
Parse article titles on build

### DIFF
--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -1,14 +1,24 @@
 import fs from "fs";
 import process from "process";
 
+function getArticleTitle(data, filename) {
+    const start = data.search(/<h1>/g);
+    const end = data.search(/<\/h1>/g);
+    if (start === -1 || end === -1)
+        throw new Error(`article ${filename} has no h1 element`);
+    return data.substring(start + 4, end);
+}
+
 function readAssetsArticlesFiles(articlesPath) {
     let files = fs.readdirSync(articlesPath);
     files = files.filter((file) => file.split(".").at(-1) === "html");
     const articles = {};
     files.forEach((file) => {
-        articles[file.slice(0, -5)] = fs.readFileSync(articlesPath + file, {
-            encoding: "utf8",
-        });
+        const data = fs.readFileSync(articlesPath + file, { encoding: "utf8" });
+        articles[file.slice(0, -5)] = {
+            title: getArticleTitle(data, file),
+            data,
+        };
     });
     return articles;
 }

--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -20,7 +20,7 @@ export function detectArticle() {
     if (window.imports.articles[query]) {
         current = query;
         outer.setAttribute("data-hidden", false);
-        inner.innerHTML = window.imports.articles[query];
+        inner.innerHTML = window.imports.articles[query].data;
         return;
     }
 

--- a/tests/anchors-to-both-article-and-map.test.js
+++ b/tests/anchors-to-both-article-and-map.test.js
@@ -19,7 +19,7 @@ describe("anchors to articles", () => {
         const moddedArticle = `
         <h1>article1</h1>
         <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map2">article2</a> more content1</p>
-    `;
+        `;
         expect(isArticleLoaded("article1", moddedArticle)).toBe(true);
         expect(isMapLoaded("map2", maps["map2"])).toBe(true);
     });

--- a/tests/back-and-forward-buttons.test.js
+++ b/tests/back-and-forward-buttons.test.js
@@ -30,7 +30,7 @@ describe("back and forward features", () => {
         const moddedArticle = `
         <h1>article1</h1>
         <p>content <a toarticle="article2" href="http://localhost/?article=article2&amp;map=map2">article2</a> more content1</p>
-    `;
+        `;
 
         expect(isArticleLoaded("article2", moddedArticles["article2"])).toBe(
             true,

--- a/tests/build-articles.test.js
+++ b/tests/build-articles.test.js
@@ -75,12 +75,37 @@ describe("buildArticles", () => {
         });
     });
 
+    describe("when the article has no title", () => {
+        beforeEach(() => {
+            readFileSyncSpy.mockReturnValue("data");
+            readdirSyncSpy.mockReturnValue(["file.html"]);
+            writeFileSyncSpy.mockImplementation(() => {});
+            buildArticles(articlesPath, buildPath);
+        });
+
+        test("should not write data to any file", () => {
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+        });
+
+        test("should log the process correctly", () => {
+            expect(writeSpy).toHaveBeenCalledWith("Building articles...");
+            expect(writeSpy).toHaveBeenCalledWith(
+                "\x1b[31m Failed \x1b[0m \n\n",
+            );
+            expect(errorSpy).toHaveBeenCalled();
+        });
+
+        test("should exit with errors", () => {
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+    });
+
     describe("when successful", () => {
-        let result = { path: "", data: "" };
+        let result = { path: "", data: {} };
         let expectedData = "";
 
         beforeEach(() => {
-            readFileSyncSpy.mockReturnValue("");
+            readFileSyncSpy.mockReturnValue("<h1>title</h1>data");
             readdirSyncSpy.mockReturnValue([
                 "file.html",
                 "nope.txt",
@@ -91,7 +116,11 @@ describe("buildArticles", () => {
                 result.data = data;
             });
             expectedData =
-                "export default " + JSON.stringify({ file: "", other: "" });
+                "export default " +
+                JSON.stringify({
+                    file: { title: "title", data: "<h1>title</h1>data" },
+                    other: { title: "title", data: "<h1>title</h1>data" },
+                });
             buildArticles(articlesPath, buildPath);
         });
 

--- a/tests/mocks/articles.js
+++ b/tests/mocks/articles.js
@@ -1,21 +1,27 @@
 export const articles = {
-    article1: `
+    article1: {
+        title: "article1",
+        data: `
         <h1>article1</h1>
         <p>content <a toarticle="article2">article2</a> more content1</p>
-    `,
-    article2: `
+        `,
+    },
+    article2: {
+        title: "article2",
+        data: `
         <h1>article2</h1>
         <p>content <a toarticle="article1">article1</a> more content2</p>
-    `,
+        `,
+    },
 };
 
 export const moddedArticles = {
     article1: `
         <h1>article1</h1>
         <p>content <a toarticle="article2" href="http://localhost/?article=article2">article2</a> more content1</p>
-    `,
+        `,
     article2: `
         <h1>article2</h1>
         <p>content <a toarticle="article1" href="http://localhost/?article=article1">article1</a> more content2</p>
-    `,
+        `,
 };


### PR DESCRIPTION
To make a proper index page, we need to print article titles. Using the file names won't work very well for a good experience, so I decided to parse it out of the `<h1>` tag on the article. Now all articles require a h1 element, which they all would probably have anyway.