### PR TITLE
Fix browser back/forward test

### DIFF
--- a/tests/back-and-forward-buttons.test.js
+++ b/tests/back-and-forward-buttons.test.js
@@ -6,7 +6,7 @@ import { isArticleLoaded } from "./utils/is-article-loaded.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
 
 // Wait time for window.history.back() or window.history.forward()
-const RELOAD_TIME = 10;
+const RELOAD_TIME = 20;
 
 describe("back and forward features", () => {
     beforeEach(async () => {


### PR DESCRIPTION
There were rare instances where this test was failing, mostly because the wait time of 10ms wasn't enough. This commit doubles the wait time so failures should become less likely, if at all possible.