### PR TITLE
Add index links on top bar

### DIFF
--- a/project-settings.json
+++ b/project-settings.json
@@ -2,7 +2,9 @@
     "title": "Work In Progress",
     "defaultMap": "map1",
     "labels": {
-        "closeArticle": "Close Article",
+        "closeArticle": "Close",
+        "articlesIndexLink": "Articles",
+        "mapsIndexLink": "Maps",
         "darkMode": "Dark Mode",
         "lightMode": "Light Mode",
         "tableOfContents": "Table of Contents"

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -1,22 +1,36 @@
 import { changeSearchParam } from "../navigation/change-search-param.js";
 import { detectArticle } from "../navigation/articles.js";
 import { detectMap } from "../navigation/maps.js";
+import { detectMenu } from "../navigation/menu.js";
 
 // This is to override the default behavior of anchors (<a></a> tags). We want
 // them to not reload the page, just change search params and re-render. This
 // function scans for anchors and does that. We're using the custom attributes
-// `toarticle` and `tomap` to move around instead of `href` so we can just
-// point to the name of the article/map and it will modify it without changing
-// the other.
+// `toarticle`, `tomap` and `tomenu` to move around instead of `href` so we can
+// just point to the name of the article/map and it will modify it without
+// changing the other.
 export function setAnchors() {
     const anchors = document.querySelectorAll("a");
     anchors.forEach((a) => {
-        if (!a.hasAttribute("toarticle") && !a.hasAttribute("tomap")) return;
+        if (
+            !a.hasAttribute("toarticle") &&
+            !a.hasAttribute("tomap") &&
+            !a.hasAttribute("tomenu")
+        )
+            return;
 
         const newState = {};
         const url = new URL(window.location.href);
         url.hash = "";
-        if (a.hasAttribute("toarticle")) {
+        const menu = a.getAttribute("tomenu");
+        if (menu) {
+            newState.menu = menu;
+            newState.article = "";
+            url.searchParams.set("menu", menu);
+            url.searchParams.delete("article");
+        } else if (a.hasAttribute("toarticle")) {
+            newState.menu = "";
+            url.searchParams.delete("menu");
             const article = a.getAttribute("toarticle");
             newState.article = article;
             if (article === "") {
@@ -25,6 +39,7 @@ export function setAnchors() {
                 url.searchParams.set("article", article);
             }
         }
+
         if (a.hasAttribute("tomap")) {
             const map = a.getAttribute("tomap");
             if (map === window.imports.settings.defaultMap || map === "") {
@@ -41,6 +56,7 @@ export function setAnchors() {
             changeSearchParam(newState);
             detectArticle();
             detectMap();
+            detectMenu();
             setAnchors();
             return false;
         };

--- a/src/initialization/setup-page.js
+++ b/src/initialization/setup-page.js
@@ -1,9 +1,4 @@
-export function setupPage() {
-    const title = document.createElement("title");
-    title.innerHTML = window.imports.settings.title;
-    document.head.appendChild(title);
-
-    // Root setup
+function setupRoot() {
     document.body.className = "overflow-hidden";
     const contentWrapper = document.createElement("main");
     contentWrapper.className =
@@ -13,16 +8,28 @@ export function setupPage() {
     mainContainer.className = "min-h-full relative";
     contentWrapper.appendChild(mainContainer);
     document.body.appendChild(contentWrapper);
+}
 
-    // Top bar
+function setupTopbar() {
     const topBar = document.createElement("header");
     topBar.className = `
         absolute top-0 left-0 right-0 h-12 bg-bg-light dark:bg-bg-dark
         shadow-black shadow-lg flex items-center justify-between px-4
     `;
     document.body.appendChild(topBar);
-    const placeholder = document.createElement("div");
-    topBar.appendChild(placeholder);
+
+    // Indexes
+    const articlesIndex = document.createElement("a");
+    articlesIndex.setAttribute("tomenu", "articles-index");
+    articlesIndex.innerHTML = window.imports.settings.labels.articlesIndexLink;
+    const mapsIndex = document.createElement("a");
+    mapsIndex.setAttribute("tomenu", "maps-index");
+    mapsIndex.innerHTML = window.imports.settings.labels.mapsIndexLink;
+    const navContainer = document.createElement("div");
+    navContainer.className = "flex gap-4";
+    navContainer.appendChild(articlesIndex);
+    navContainer.appendChild(mapsIndex);
+    topBar.appendChild(navContainer);
 
     // Theme switcher link
     const themeSwitcher = document.createElement("button");
@@ -30,14 +37,18 @@ export function setupPage() {
     themeSwitcher.className =
         "outlined border-2 rounded-full px-0 aspect-square";
     topBar.appendChild(themeSwitcher);
+}
 
-    // Map container
+function setupMapContainer() {
+    const mainContainer = document.getElementById("main-container");
     const mapContainer = document.createElement("div");
     mapContainer.id = "map-container";
     mapContainer.className = "h-full w-full";
     mainContainer.appendChild(mapContainer);
+}
 
-    // Article container
+function setupArticleContainer() {
+    const mainContainer = document.getElementById("main-container");
     const articleContainerOuter = document.createElement("div");
     articleContainerOuter.id = "article-container-outer";
     articleContainerOuter.className = `
@@ -56,7 +67,7 @@ export function setupPage() {
         "absolute top-8 bottom-0 left-0 right-0 px-4 pb-4 overflow-scroll";
     articleContainerMid.appendChild(articleContainerInner);
 
-    // Container for the close article and theme switcher
+    // Container for the close article link
     const articleControlPanel = document.createElement("div");
     articleControlPanel.className =
         "absolute top-0 left-4 right-4 h-8 flex justify-between items-center";
@@ -67,4 +78,17 @@ export function setupPage() {
     closeArticleBtn.setAttribute("toarticle", "");
     closeArticleBtn.innerHTML = window.imports.settings.labels.closeArticle;
     articleControlPanel.appendChild(closeArticleBtn);
+}
+
+export function setupPage() {
+    // Setup document head
+    const title = document.createElement("title");
+    title.innerHTML = window.imports.settings.title;
+    document.head.appendChild(title);
+
+    // Setup document body
+    setupRoot();
+    setupTopbar();
+    setupMapContainer();
+    setupArticleContainer();
 }

--- a/src/navigation/menu.js
+++ b/src/navigation/menu.js
@@ -47,17 +47,22 @@ function setupArticlesIndex() {
     outer.setAttribute("data-hidden", false);
     inner.innerHTML = "";
 
+    // Putting everything inside this container for test purposes
+    const container = document.createElement("dev");
+    container.id = "menu-container";
+    inner.appendChild(container);
+
     const articleHeader = document.createElement("h1");
     articleHeader.innerHTML = "Articles Index";
-    inner.appendChild(articleHeader);
+    container.appendChild(articleHeader);
 
     const index = getOrderedArticles();
     Object.keys(index).forEach((letter) => {
         const letterHeader = document.createElement("h3");
         letterHeader.innerHTML = letter;
-        inner.appendChild(letterHeader);
+        container.appendChild(letterHeader);
         const list = document.createElement("ul");
-        inner.appendChild(list);
+        container.appendChild(list);
 
         index[letter].forEach((article) => {
             const li = document.createElement("li");
@@ -77,17 +82,22 @@ function setupMapsIndex() {
     outer.setAttribute("data-hidden", false);
     inner.innerHTML = "";
 
+    // Putting everything inside this container for test purposes
+    const container = document.createElement("dev");
+    container.id = "menu-container";
+    inner.appendChild(container);
+
     const mapsHeader = document.createElement("h1");
     mapsHeader.innerHTML = "Maps Index";
-    inner.appendChild(mapsHeader);
+    container.appendChild(mapsHeader);
 
     const index = getOrderedMaps();
     Object.keys(index).forEach((letter) => {
         const letterHeader = document.createElement("h3");
         letterHeader.innerHTML = letter;
-        inner.appendChild(letterHeader);
+        container.appendChild(letterHeader);
         const list = document.createElement("ul");
-        inner.appendChild(list);
+        container.appendChild(list);
 
         index[letter].forEach((map) => {
             const li = document.createElement("li");

--- a/tests/anchors-clear-hash.test.js
+++ b/tests/anchors-clear-hash.test.js
@@ -3,7 +3,7 @@ import { moddedArticles } from "./mocks/articles.js";
 import { initDom } from "./utils/init-dom.js";
 import { isArticleLoaded } from "./utils/is-article-loaded.js";
 
-describe("anchors to close article", () => {
+describe("anchors to clear hash", () => {
     beforeEach(async () => {
         const a1 = document.createElement("a");
         a1.href = "http://localhost/?article=article1#hash";

--- a/tests/anchors-to-articles-clear-menu.test.js
+++ b/tests/anchors-to-articles-clear-menu.test.js
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { moddedArticles } from "./mocks/articles.js";
+import { initDom } from "./utils/init-dom.js";
+import { isArticleLoaded } from "./utils/is-article-loaded.js";
+
+describe("anchors to articles clear menu", () => {
+    beforeEach(async () => {
+        const a1 = document.createElement("a");
+        a1.href = "http://localhost/?menu=maps-index";
+        const a2 = document.createElement("a");
+        a2.setAttribute("toarticle", "article1");
+        await initDom([a1, a2]);
+        a1.click();
+        a2.click();
+    });
+
+    test("should go to article1 and close menu", () => {
+        expect(isArticleLoaded("article1", moddedArticles.article1)).toBe(true);
+        expect(new URL(document.location.href).searchParams.has("menu")).toBe(
+            false,
+        );
+    });
+});

--- a/tests/anchors-to-both-article-and-map.test.js
+++ b/tests/anchors-to-both-article-and-map.test.js
@@ -13,7 +13,7 @@ describe("anchors to articles", () => {
         test.click();
     });
 
-    test("should update search params and load map", () => {
+    test("should update search params and load map and article", () => {
         // Can't use moddedArticles.article1 here because of the aditional map
         // link after setAnchors.
         const moddedArticle = `

--- a/tests/anchors-to-both-menu-and-map.test.js
+++ b/tests/anchors-to-both-menu-and-map.test.js
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { maps } from "./mocks/maps.js";
+import { initDom } from "./utils/init-dom.js";
+import { isMapLoaded } from "./utils/is-map-loaded.js";
+import { isMenuLoaded } from "./utils/is-menu-loaded.js";
+
+describe("anchors to articles", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("tomenu", "articles-index");
+        test.setAttribute("tomap", "map2");
+        await initDom([test]);
+        test.click();
+    });
+
+    test("should update search params and load map and menu", () => {
+        expect(isMenuLoaded("articles-index")).toBe(true);
+        expect(isMapLoaded("map2", maps["map2"])).toBe(true);
+    });
+});

--- a/tests/anchors-to-menu.test.js
+++ b/tests/anchors-to-menu.test.js
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { isMenuLoaded } from "./utils/is-menu-loaded.js";
+
+describe("anchors to menu", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("tomenu", "articles-index");
+        await initDom([test]);
+        test.click();
+    });
+
+    test("should update search params and load articles-index", () => {
+        expect(isMenuLoaded("articles-index")).toBe(true);
+    });
+});

--- a/tests/utils/is-menu-loaded.js
+++ b/tests/utils/is-menu-loaded.js
@@ -1,0 +1,26 @@
+import { expect } from "@jest/globals";
+
+export function isMenuLoaded(name) {
+    const inner = document.getElementById("article-container-inner");
+    const outer = document.getElementById("article-container-outer");
+    const params = new URL(document.location.href).searchParams;
+
+    let check = true;
+
+    expect(params.get("menu")).toBe(name);
+    if (params.get("menu") !== name) check = false;
+
+    expect(inner.querySelector("#menu-container")).not.toBeNull();
+    if (inner.querySelector("#menu-container") === null) check = false;
+
+    expect(outer.getAttribute("data-hidden")).toBe(
+        name === null ? "true" : "false",
+    );
+    if (
+        outer.getAttribute("data-hidden") !== (name === null ? "true" : "false")
+    ) {
+        check = false;
+    }
+
+    return check;
+}


### PR DESCRIPTION
Add links to the articles index and the maps index on the top bar. To do this, we needed to add the `tomenu` attribute functionality to anchors in a similar manner to the previous `tomap` and `toarticle` attributes. This new one has special behavior with the `toarticle` attribute, as both menus and articles occupy the same container, only one of them can be loaded at the same time, so I'm giving priority to the `tomenu` property, which means an anchor with both `tomenu` and `toarticle` will ignore the `toarticle`, and if there is either a menu or article loaded and you click an anchor to the other, the previous one will get cleared out of the search params.

There's also a couple of typo corrections in this commit as well, on the anchor tests.