### PR TITLE
Refactor inexisting articles

### DIFF
--- a/project-settings.json
+++ b/project-settings.json
@@ -7,6 +7,7 @@
         "mapsIndexLink": "Maps",
         "darkMode": "Dark Mode",
         "lightMode": "Light Mode",
-        "tableOfContents": "Table of Contents"
+        "tableOfContents": "Table of Contents",
+        "articleNotFound": "Article not found"
     }
 }

--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -1,6 +1,17 @@
-import { changeSearchParam } from "./change-search-param.js";
-
 let current = "";
+
+function articleNotFound() {
+    const inner = document.getElementById("article-container-inner");
+    const container = document.createElement("div");
+    const h3 = document.createElement("h3");
+    const p = document.createElement("p");
+    container.id = "article-not-found";
+    h3.innerHTML = "404";
+    p.innerHTML = window.imports.settings.labels.articleNotFound;
+    container.appendChild(h3);
+    container.appendChild(p);
+    inner.appendChild(container);
+}
 
 export function detectArticle() {
     const outer = document.getElementById("article-container-outer");
@@ -26,8 +37,7 @@ export function detectArticle() {
         return;
     }
 
-    current = "";
-    outer.setAttribute("data-hidden", true);
-    inner.innerHTML = "";
-    changeSearchParam({ article: "" });
+    current = query;
+    outer.setAttribute("data-hidden", false);
+    articleNotFound();
 }

--- a/tests/anchors-to-inexistent-article.test.js
+++ b/tests/anchors-to-inexistent-article.test.js
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+
+describe("anchors to inexistent article", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("toarticle", "nope");
+        await initDom([test]);
+        test.click();
+    });
+
+    test("should update search params and load article", () => {
+        const inner = document.getElementById("article-container-inner");
+        expect(inner.querySelector("#article-not-found")).not.toBeNull();
+    });
+});


### PR DESCRIPTION
Instead of rerouting to `?article=""`, we're not showing a 404 error message. It's better UX, as the user has more information of what just happened instead of just having nothing happening or having a previous article close instead. It also removes all usage of `pushState()` other than direct user input.