### PR TITLE
Refactor inexisting maps

### DIFF
--- a/project-settings.json
+++ b/project-settings.json
@@ -8,6 +8,7 @@
         "darkMode": "Dark Mode",
         "lightMode": "Light Mode",
         "tableOfContents": "Table of Contents",
-        "articleNotFound": "Article not found"
+        "articleNotFound": "Article not found",
+        "mapNotFound": "Map not found"
     }
 }

--- a/src/initialization/setup-page.js
+++ b/src/initialization/setup-page.js
@@ -1,8 +1,10 @@
 function setupRoot() {
     document.body.className = "overflow-hidden";
     const contentWrapper = document.createElement("main");
-    contentWrapper.className =
-        "absolute top-12 left-0 bottom-0 right-0 overflow-scroll";
+    contentWrapper.className = `
+        absolute top-12 left-0 bottom-0 right-0 overflow-scroll bg-bg-light
+        dark:bg-bg-dark
+    `;
     const mainContainer = document.createElement("div");
     mainContainer.id = "main-container";
     mainContainer.className = "min-h-full relative";

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -1,8 +1,20 @@
-import { changeSearchParam } from "./change-search-param.js";
-
 const imagesPath = "./assets/images/";
 
 let current = "";
+
+function mapNotFound() {
+    const mapContainer = document.getElementById("map-container");
+    const container = document.createElement("div");
+    const h3 = document.createElement("h3");
+    const p = document.createElement("p");
+    container.id = "map-not-found";
+    container.className = "m-4";
+    h3.innerHTML = "404";
+    p.innerHTML = window.imports.settings.labels.mapNotFound;
+    container.appendChild(h3);
+    container.appendChild(p);
+    mapContainer.appendChild(container);
+}
 
 function loadMap(data) {
     const mainContainer = document.getElementById("main-container");
@@ -49,17 +61,18 @@ export function detectMap() {
     if (query === current) return;
 
     if (query === null) {
+        current = "";
         const defaultMap = window.imports.settings.defaultMap;
         loadMap(window.imports.maps[defaultMap]);
         return;
     }
 
     if (window.imports.maps[query]) {
+        current = query;
         loadMap(window.imports.maps[query]);
         return;
     }
 
-    const defaultMap = window.imports.settings.defaultMap;
-    loadMap(window.imports.maps[defaultMap]);
-    changeSearchParam({ map: "" });
+    current = query;
+    mapNotFound();
 }

--- a/tests/anchors-to-inexistent-map.test.js
+++ b/tests/anchors-to-inexistent-map.test.js
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { initDom } from "./utils/init-dom.js";
 
-describe("anchors to inexistent article", () => {
+describe("anchors to inexistent map", () => {
     beforeEach(async () => {
         const test = document.createElement("a");
-        test.setAttribute("toarticle", "nope");
+        test.setAttribute("tomap", "nope");
         await initDom([test]);
         test.click();
     });
 
     test("should update search params and load 404 message", () => {
-        const inner = document.getElementById("article-container-inner");
-        expect(inner.querySelector("#article-not-found")).not.toBeNull();
+        const container = document.getElementById("map-container");
+        expect(container.querySelector("#map-not-found")).not.toBeNull();
     });
 });


### PR DESCRIPTION
Just like articles, we should show a 404 error message instead of falling back to default map when the user inputs an inexisting map URL. This is better UX as the user has more information of what just happened and it removes all `pushState()` calls from non direct user input.