### PR TITLE
Fix navigation between articles and menus bug

### DIFF
--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -1,5 +1,3 @@
-let current = "";
-
 function articleNotFound() {
     const inner = document.getElementById("article-container-inner");
     const container = document.createElement("div");
@@ -21,23 +19,18 @@ export function detectArticle() {
 
     if (params.has("menu")) return;
 
-    if (query === current) return;
-
     if (query === null) {
-        current = "";
         outer.setAttribute("data-hidden", true);
         inner.innerHTML = "";
         return;
     }
 
     if (window.imports.articles[query]) {
-        current = query;
         outer.setAttribute("data-hidden", false);
         inner.innerHTML = window.imports.articles[query].data;
         return;
     }
 
-    current = query;
     outer.setAttribute("data-hidden", false);
     articleNotFound();
 }

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -1,7 +1,5 @@
 const imagesPath = "./assets/images/";
 
-let current = "";
-
 function mapNotFound() {
     const mapContainer = document.getElementById("map-container");
     const container = document.createElement("div");
@@ -58,21 +56,16 @@ export function detectMap() {
     const params = new URLSearchParams(window.location.search);
     const query = params.get("map");
 
-    if (query === current) return;
-
     if (query === null) {
-        current = "";
         const defaultMap = window.imports.settings.defaultMap;
         loadMap(window.imports.maps[defaultMap]);
         return;
     }
 
     if (window.imports.maps[query]) {
-        current = query;
         loadMap(window.imports.maps[query]);
         return;
     }
 
-    current = query;
     mapNotFound();
 }

--- a/src/navigation/menu.js
+++ b/src/navigation/menu.js
@@ -1,7 +1,5 @@
 import { changeSearchParam } from "./change-search-param.js";
 
-let current = "";
-
 function getOrderedArticles() {
     const articles = Object.keys(window.imports.articles).map((article) => ({
         title: window.imports.articles[article].title,
@@ -41,7 +39,6 @@ function getOrderedMaps() {
 }
 
 function setupArticlesIndex() {
-    current = "articles-index";
     const outer = document.getElementById("article-container-outer");
     const inner = document.getElementById("article-container-inner");
     outer.setAttribute("data-hidden", false);
@@ -76,7 +73,6 @@ function setupArticlesIndex() {
 }
 
 function setupMapsIndex() {
-    current = "maps-index";
     const outer = document.getElementById("article-container-outer");
     const inner = document.getElementById("article-container-inner");
     outer.setAttribute("data-hidden", false);
@@ -118,10 +114,7 @@ export function detectMenu() {
 
     if (params.has("article")) return;
 
-    if (query === current) return;
-
     if (query === null) {
-        current = "";
         outer.setAttribute("data-hidden", true);
         inner.innerHTML = "";
         return;
@@ -137,7 +130,6 @@ export function detectMenu() {
         return;
     }
 
-    current = "";
     outer.setAttribute("data-hidden", true);
     inner.innerHTML = "";
     changeSearchParam({ menu: "" });


### PR DESCRIPTION
There was a bug due to how going from an article to a menu and vice versa wouldn't clear the `current` variable in either, causing the detect function to not do anything when going from an article back to the last menu loaded or going from a menu to the previously loaded article.

This commit just removes this variable, it is no long necessary. It never was in fact necessary, we just wanted to prevent any changes from happening when the user went from an article to the same article (would probably cause the article to scroll back to the top), which might be worse UX when you think about it, as nothing happening when the user clicks a link/button should be avoided.