### PR TITLE
Add non-existent menu page

### DIFF
--- a/project-settings.json
+++ b/project-settings.json
@@ -9,6 +9,7 @@
         "lightMode": "Light Mode",
         "tableOfContents": "Table of Contents",
         "articleNotFound": "Article not found",
-        "mapNotFound": "Map not found"
+        "mapNotFound": "Map not found",
+        "menuNotFound": "Menu not found"
     }
 }

--- a/src/navigation/menu.js
+++ b/src/navigation/menu.js
@@ -1,4 +1,15 @@
-import { changeSearchParam } from "./change-search-param.js";
+function menuNotFound() {
+    const inner = document.getElementById("article-container-inner");
+    const container = document.createElement("div");
+    const h3 = document.createElement("h3");
+    const p = document.createElement("p");
+    container.id = "menu-not-found";
+    h3.innerHTML = "404";
+    p.innerHTML = window.imports.settings.labels.menuNotFound;
+    container.appendChild(h3);
+    container.appendChild(p);
+    inner.appendChild(container);
+}
 
 function getOrderedArticles() {
     const articles = Object.keys(window.imports.articles).map((article) => ({
@@ -130,7 +141,6 @@ export function detectMenu() {
         return;
     }
 
-    outer.setAttribute("data-hidden", true);
-    inner.innerHTML = "";
-    changeSearchParam({ menu: "" });
+    outer.setAttribute("data-hidden", false);
+    menuNotFound();
 }

--- a/tests/anchors-to-inexistent-menu.test.js
+++ b/tests/anchors-to-inexistent-menu.test.js
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+
+describe("anchors to inexistent article", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("tomenu", "nope");
+        await initDom([test]);
+        test.click();
+    });
+
+    test("should update search params and load 404 message", () => {
+        const inner = document.getElementById("article-container-inner");
+        expect(inner.querySelector("#menu-not-found")).not.toBeNull();
+    });
+});


### PR DESCRIPTION
Articles and maps send a 404 message when the search param contains a string for an article/map that doesn't exist. Same thing should happen to menus.