### PR TITLE
Refactor detect maps with fetch

### DIFF
--- a/scripts/build-settings.js
+++ b/scripts/build-settings.js
@@ -11,6 +11,7 @@ export function buildSettings(settingsPath, buildPath) {
         const settings = readProjectSettings(settingsPath);
         settings.paths = {
             articles: (process.env.REPO_NAME || "") + "/assets/articles/",
+            maps: (process.env.REPO_NAME || "") + "/assets/maps/",
         };
         const data = "export default " + JSON.stringify(settings);
         fs.writeFileSync(buildPath, data);

--- a/tests/anchors-to-both-menu-and-map.test.js
+++ b/tests/anchors-to-both-menu-and-map.test.js
@@ -3,6 +3,9 @@ import { maps } from "./mocks/maps.js";
 import { initDom } from "./utils/init-dom.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
 import { isMenuLoaded } from "./utils/is-menu-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
 
 describe("anchors to articles", () => {
     beforeEach(async () => {

--- a/tests/anchors-to-inexistent-map.test.js
+++ b/tests/anchors-to-inexistent-map.test.js
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import { initDom } from "./utils/init-dom.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
 
 describe("anchors to inexistent map", () => {
     beforeEach(async () => {
@@ -10,7 +13,13 @@ describe("anchors to inexistent map", () => {
     });
 
     test("should update search params and load 404 message", () => {
-        const container = document.getElementById("map-container");
-        expect(container.querySelector("#map-not-found")).not.toBeNull();
+        const contents = document.getElementById("map-container").children;
+        expect(contents.length).toBe(1);
+        const container = contents[0];
+        expect(container.children.length).toBe(2);
+        expect(container.children[0].tagName).toBe("H3");
+        expect(container.children[0].innerHTML).toBe("404");
+        expect(container.children[1].tagName).toBe("P");
+        expect(container.children[1].innerHTML).toBe("File not found.");
     });
 });

--- a/tests/anchors-to-maps.test.js
+++ b/tests/anchors-to-maps.test.js
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
 import { maps } from "./mocks/maps.js";
 import { initDom } from "./utils/init-dom.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
 
 describe("anchors to articles", () => {
     beforeEach(async () => {

--- a/tests/anchors-to-no-map.test.js
+++ b/tests/anchors-to-no-map.test.js
@@ -3,8 +3,11 @@ import { maps } from "./mocks/maps.js";
 import { settings } from "./mocks/settings.js";
 import { initDom } from "./utils/init-dom.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
 
-describe("anchors to articles", () => {
+mockFetch();
+
+describe("anchors to no map", () => {
     beforeEach(async () => {
         const test = document.createElement("a");
         test.setAttribute("tomap", "");

--- a/tests/build-settings.test.js
+++ b/tests/build-settings.test.js
@@ -61,7 +61,10 @@ describe("buildSettings", () => {
             expectedData =
                 "export default " +
                 JSON.stringify({
-                    paths: { articles: "repo/assets/articles/" },
+                    paths: {
+                        articles: "repo/assets/articles/",
+                        maps: "repo/assets/maps/",
+                    },
                 });
             buildSettings(settingsPath, buildPath);
         });

--- a/tests/map-on-load.test.js
+++ b/tests/map-on-load.test.js
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
 import { maps } from "./mocks/maps.js";
 import { initDom } from "./utils/init-dom.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
 
 describe("map on load", () => {
     beforeEach(async () => {

--- a/tests/mocks/settings.js
+++ b/tests/mocks/settings.js
@@ -6,5 +6,6 @@ export const settings = {
     },
     paths: {
         articles: "/assets/articles/",
+        maps: "/assets/maps/",
     },
 };

--- a/tests/utils/mock-fetch.js
+++ b/tests/utils/mock-fetch.js
@@ -1,5 +1,6 @@
 import { jest } from "@jest/globals";
 import { articles } from "../mocks/articles.js";
+import { maps } from "../mocks/maps.js";
 
 export function mockFetch() {
     window.fetch = jest.fn((url) => {
@@ -13,6 +14,16 @@ export function mockFetch() {
                 return Promise.resolve({
                     ok: true,
                     text: () => Promise.resolve(articles.article2.data),
+                });
+            case "/assets/maps/map1.json":
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve(maps.map1),
+                });
+            case "/assets/maps/map2.json":
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve(maps.map2),
                 });
             default:
                 return Promise.resolve({


### PR DESCRIPTION
Continuing with the fetch refactor, this commit refactor `detectMaps()` to load maps by fetching them instead of reading from memory. Also like the articles refactor, it isn't erasing the build maps step yet, it's just replacing the read from memory for a fetch.