### PR TITLE
Fix flickering and improve tests

### DIFF
--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -1,19 +1,28 @@
 import { setAnchors } from "../components/anchor.js";
 
+let current = "";
+
 export async function detectArticle() {
     const outer = document.getElementById("article-container-outer");
     const inner = document.getElementById("article-container-inner");
     const params = new URLSearchParams(window.location.search);
     const query = params.get("article");
 
-    if (params.has("menu")) return;
+    if (query === current) return;
+
+    if (params.has("menu")) {
+        current = "";
+        return;
+    }
 
     if (query === null) {
+        current = "";
         outer.setAttribute("data-hidden", true);
         inner.innerHTML = "";
         return;
     }
 
+    current = query;
     outer.setAttribute("data-hidden", false);
     inner.innerHTML = `<p>${window.settings.labels.loading}</p>`;
     try {

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -2,6 +2,8 @@ import { setAnchors } from "../components/anchor.js";
 
 const imagesPath = "./assets/images/";
 
+let current = "";
+
 function loadMap(data) {
     const mainContainer = document.getElementById("main-container");
     const container = document.getElementById("map-container");
@@ -45,8 +47,11 @@ export async function detectMap() {
     const params = new URLSearchParams(window.location.search);
     const query = params.get("map") || window.settings.defaultMap;
     const container = document.getElementById("map-container");
-    container.innerHTML = `<p>${window.settings.labels.loading}</p>`;
 
+    if (query === current) return;
+
+    current = query;
+    container.innerHTML = `<p>${window.settings.labels.loading}</p>`;
     try {
         const res = await fetch(`${window.settings.paths.maps}${query}.json`);
         if (!res.ok) {

--- a/src/navigation/menu.js
+++ b/src/navigation/menu.js
@@ -1,19 +1,28 @@
 import { setAnchors } from "../components/anchor.js";
 
+let current = "";
+
 export async function detectMenu() {
     const outer = document.getElementById("article-container-outer");
     const inner = document.getElementById("article-container-inner");
     const params = new URLSearchParams(window.location.search);
     const query = params.get("menu");
 
-    if (params.has("article")) return;
+    if (query === current) return;
+
+    if (params.has("article") && query === null) {
+        current = "";
+        return;
+    }
 
     if (query === null) {
+        current = "";
         outer.setAttribute("data-hidden", true);
         inner.innerHTML = "";
         return;
     }
 
+    current = query;
     outer.setAttribute("data-hidden", false);
     inner.innerHTML = `<p>${window.settings.labels.loading}</p>`;
     try {

--- a/tests/anchors-to-both-article-and-map.test.js
+++ b/tests/anchors-to-both-article-and-map.test.js
@@ -7,7 +7,7 @@ import { mockFetch } from "./utils/mock-fetch.js";
 
 mockFetch();
 
-describe("anchors to articles", () => {
+describe("anchors to both article and map", () => {
     beforeEach(async () => {
         const test = document.createElement("a");
         test.setAttribute("toarticle", "article1");

--- a/tests/anchors-to-both-article-and-menu.test.js
+++ b/tests/anchors-to-both-article-and-menu.test.js
@@ -1,23 +1,20 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
-import { maps } from "./mocks/maps.js";
 import { initDom } from "./utils/init-dom.js";
-import { isMapLoaded } from "./utils/is-map-loaded.js";
 import { isMenuLoaded } from "./utils/is-menu-loaded.js";
 import { mockFetch } from "./utils/mock-fetch.js";
 
 mockFetch();
 
-describe("anchors to both menu and map", () => {
+describe("anchors to both article and menu", () => {
     beforeEach(async () => {
         const test = document.createElement("a");
         test.setAttribute("tomenu", "articles-index");
-        test.setAttribute("tomap", "map2");
+        test.setAttribute("toarticle", "article1");
         await initDom([test]);
         test.click();
     });
 
-    test("should update search params and load map and menu", () => {
+    test("should update search params and load only the menu", () => {
         expect(isMenuLoaded("articles-index")).toBe(true);
-        expect(isMapLoaded("map2", maps["map2"])).toBe(true);
     });
 });

--- a/tests/anchors-to-same-article.test.js
+++ b/tests/anchors-to-same-article.test.js
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
+
+describe("anchors to same article", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("tomap", "map2");
+        await initDom([test], { article: "article1" });
+        test.click();
+    });
+
+    test("should fetch for article only once", () => {
+        expect(window.fetch).toHaveBeenCalledTimes(3);
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json");
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith(
+            "/assets/articles/article1.html",
+        );
+    });
+});

--- a/tests/anchors-to-same-map.test.js
+++ b/tests/anchors-to-same-map.test.js
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
+
+describe("anchors to same map", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("toarticle", "article1");
+        await initDom([test], { map: "map2" });
+        test.click();
+    });
+
+    test("should fetch for maps only once", () => {
+        expect(window.fetch).toHaveBeenCalledTimes(2);
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith(
+            "/assets/articles/article1.html",
+        );
+    });
+});

--- a/tests/anchors-to-same-menu.test.js
+++ b/tests/anchors-to-same-menu.test.js
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+
+mockFetch();
+
+describe("anchors to same menu", () => {
+    beforeEach(async () => {
+        const test = document.createElement("a");
+        test.setAttribute("tomap", "map2");
+        await initDom([test], { menu: "maps-index" });
+        test.click();
+    });
+
+    test("should fetch for menu only once", () => {
+        expect(window.fetch).toHaveBeenCalledTimes(3);
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json");
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith(
+            "/build/menu/maps-index.html",
+        );
+    });
+});

--- a/tests/back-and-forward-buttons.test.js
+++ b/tests/back-and-forward-buttons.test.js
@@ -5,6 +5,7 @@ import { initDom } from "./utils/init-dom.js";
 import { isArticleLoaded } from "./utils/is-article-loaded.js";
 import { isMapLoaded } from "./utils/is-map-loaded.js";
 import { mockFetch } from "./utils/mock-fetch.js";
+import { sleep } from "./utils/sleep.js";
 
 mockFetch();
 
@@ -40,22 +41,22 @@ describe("back and forward features", () => {
         );
         expect(isMapLoaded(null, maps["map1"])).toBe(true);
         window.history.back();
-        await new Promise((r) => setTimeout(r, RELOAD_TIME));
+        await sleep(RELOAD_TIME);
 
         expect(isArticleLoaded("article1", moddedArticle)).toBe(true);
         expect(isMapLoaded("map2", maps["map2"])).toBe(true);
         window.history.back();
-        await new Promise((r) => setTimeout(r, RELOAD_TIME));
+        await sleep(RELOAD_TIME);
 
         expect(isArticleLoaded(null, "")).toBe(true);
         expect(isMapLoaded(null, maps["map1"])).toBe(true);
         window.history.forward();
-        await new Promise((r) => setTimeout(r, RELOAD_TIME));
+        await sleep(RELOAD_TIME);
 
         expect(isArticleLoaded("article1", moddedArticle)).toBe(true);
         expect(isMapLoaded("map2", maps["map2"])).toBe(true);
         window.history.forward();
-        await new Promise((r) => setTimeout(r, RELOAD_TIME));
+        await sleep(RELOAD_TIME);
 
         expect(isArticleLoaded("article2", moddedArticles["article2"])).toBe(
             true,

--- a/tests/navigating-from-article-to-menu.test.js
+++ b/tests/navigating-from-article-to-menu.test.js
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { moddedArticles } from "./mocks/articles.js";
+import { initDom } from "./utils/init-dom.js";
+import { isArticleLoaded } from "./utils/is-article-loaded.js";
+import { isMenuLoaded } from "./utils/is-menu-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+import { sleep } from "./utils/sleep.js";
+
+const SLEEP_TIME = 20;
+
+mockFetch();
+
+// This test is because the code made to prevent flickering due to when we
+// navigate to any link, causing both maps and articles/menu to refetch at
+// some point could get confused and store the wrong values on the "current"
+// variable for both articles and menu, causing it to not load the right
+// article/menu. This test recreates the conditions that caused it so we
+// know if it ever came back.
+
+describe("navigating from article to menu", () => {
+    const a1 = document.createElement("a");
+    a1.setAttribute("tomenu", "articles-index");
+    const a2 = document.createElement("a");
+    a2.setAttribute("toarticle", "article1");
+
+    beforeEach(async () => {
+        await initDom([a1, a2]);
+    });
+
+    test("should be able to go back and forth to the same article and menu", async () => {
+        a1.click();
+        await sleep(SLEEP_TIME);
+        expect(isMenuLoaded("articles-index")).toBe(true);
+
+        a2.click();
+        await sleep(SLEEP_TIME);
+        expect(isArticleLoaded("article1", moddedArticles.article1)).toBe(true);
+
+        a1.click();
+        await sleep(SLEEP_TIME);
+        expect(isMenuLoaded("articles-index")).toBe(true);
+
+        a2.click();
+        await sleep(SLEEP_TIME);
+        expect(isArticleLoaded("article1", moddedArticles.article1)).toBe(true);
+
+        a1.click();
+        await sleep(SLEEP_TIME);
+        expect(isMenuLoaded("articles-index")).toBe(true);
+    });
+});

--- a/tests/utils/sleep.js
+++ b/tests/utils/sleep.js
@@ -1,0 +1,3 @@
+export function sleep(time) {
+    return new Promise((r) => setTimeout(r, time));
+}


### PR DESCRIPTION
Whenever we navigated anywhere, the screen would flicker. That was because the map was reloading even though we didn't changed it. Changing just the map would cause the menu or article to flicker as well, for the same reason.

To fix it, we returned the code that was preventing needless re-renders with a `current` variable storing the currently loaded article/menu/map and not doing anything in case the new one to be render is the same.

This code was removed because it caused a bug when navigating from an article to a menu and back to the same article, or from a menu to an article and back to the same menu. So we put this code back but in a way that would not cause this bug, as well as with a test to ensure this bug hasn't returned

While making the new tests (the one for the old bug and for the new anti flickering feature), we saw some tests with typos and one test was missing (anchors to both menus and articles), so this commit also fixes it.