### PR TITLE
Disable cache when fetching for articles, maps and menus

### DIFF
--- a/src/navigation/articles.js
+++ b/src/navigation/articles.js
@@ -25,6 +25,7 @@ export async function detectArticle() {
     try {
         const res = await fetch(
             `${window.settings.paths.articles}${query}.html`,
+            { cache: "no-store" },
         );
         if (!res.ok) {
             throw {

--- a/src/navigation/maps.js
+++ b/src/navigation/maps.js
@@ -13,7 +13,9 @@ export async function detectMap() {
     current = query;
     container.innerHTML = `<p>${window.settings.labels.loading}</p>`;
     try {
-        const res = await fetch(`${window.settings.paths.maps}${query}.json`);
+        const res = await fetch(`${window.settings.paths.maps}${query}.json`, {
+            cache: "no-store",
+        });
         if (!res.ok) {
             throw {
                 status: res.status,

--- a/src/navigation/menu.js
+++ b/src/navigation/menu.js
@@ -23,7 +23,9 @@ export async function detectMenu() {
     current = query;
     setArticleModal(`<p>${window.settings.labels.loading}</p>`);
     try {
-        const res = await fetch(`${window.settings.paths.menu}${query}.html`);
+        const res = await fetch(`${window.settings.paths.menu}${query}.html`, {
+            cache: "no-store",
+        });
         if (!res.ok) {
             throw {
                 status: res.status,

--- a/tests/anchors-to-same-article.test.js
+++ b/tests/anchors-to-same-article.test.js
@@ -14,10 +14,15 @@ describe("anchors to same article", () => {
 
     test("should fetch for article only once", () => {
         expect(window.fetch).toHaveBeenCalledTimes(3);
-        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json");
-        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json", {
+            cache: "no-store",
+        });
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json", {
+            cache: "no-store",
+        });
         expect(window.fetch).toHaveBeenCalledWith(
             "/assets/articles/article1.html",
+            { cache: "no-store" },
         );
     });
 });

--- a/tests/anchors-to-same-map.test.js
+++ b/tests/anchors-to-same-map.test.js
@@ -14,9 +14,12 @@ describe("anchors to same map", () => {
 
     test("should fetch for maps only once", () => {
         expect(window.fetch).toHaveBeenCalledTimes(2);
-        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json", {
+            cache: "no-store",
+        });
         expect(window.fetch).toHaveBeenCalledWith(
             "/assets/articles/article1.html",
+            { cache: "no-store" },
         );
     });
 });

--- a/tests/anchors-to-same-menu.test.js
+++ b/tests/anchors-to-same-menu.test.js
@@ -14,10 +14,15 @@ describe("anchors to same menu", () => {
 
     test("should fetch for menu only once", () => {
         expect(window.fetch).toHaveBeenCalledTimes(3);
-        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json");
-        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json");
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map1.json", {
+            cache: "no-store",
+        });
+        expect(window.fetch).toHaveBeenCalledWith("/assets/maps/map2.json", {
+            cache: "no-store",
+        });
         expect(window.fetch).toHaveBeenCalledWith(
             "/build/menu/maps-index.html",
+            { cache: "no-store" },
         );
     });
 });


### PR DESCRIPTION
Because they are constantly changing and I can't control the GitHub Pages server headers (not that I know), it's easier to just disable the cache than to expect your users to know how and when to refresh them.

We could make an more robust build system to include some versioning on the names of every fetchable resource but I don't think it's going to be a problem for now as HTML and JSON files are very light, so fetching them every time shouldn't be problematic.