### PR TITLE
Fix initial article

### DIFF
--- a/src/initialization/setup-page.js
+++ b/src/initialization/setup-page.js
@@ -34,7 +34,12 @@ export function setupPage() {
     // Initial article
     const params = new URLSearchParams(window.location.search);
     const initialArticle = window.settings.initialArticle;
-    if (initialArticle && !params.has("articles")) {
+    if (
+        initialArticle &&
+        !params.has("article") &&
+        !params.has("menu") &&
+        !params.has("map")
+    ) {
         changeSearchParam({ article: initialArticle });
     }
 }

--- a/tests/initial-article-success.test.js
+++ b/tests/initial-article-success.test.js
@@ -9,7 +9,7 @@ jest.mock("./mocks/settings.js");
 
 mockFetch();
 
-describe("initial article", () => {
+describe("initial article success", () => {
     beforeEach(async () => {
         settings.initialArticle = "article1";
         await initDom();

--- a/tests/initial-article-with-article.test.js
+++ b/tests/initial-article-with-article.test.js
@@ -1,0 +1,21 @@
+import { jest, beforeEach, describe, expect, test } from "@jest/globals";
+import { moddedArticles } from "./mocks/articles.js";
+import { initDom } from "./utils/init-dom.js";
+import { isArticleLoaded } from "./utils/is-article-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+import { settings } from "./mocks/settings.js";
+
+jest.mock("./mocks/settings.js");
+
+mockFetch();
+
+describe("initial article with article", () => {
+    beforeEach(async () => {
+        settings.initialArticle = "article2";
+        await initDom([], { article: "article1" });
+    });
+
+    test("should not load article on start", () => {
+        expect(isArticleLoaded("article1", moddedArticles.article1)).toBe(true);
+    });
+});

--- a/tests/initial-article-with-map.test.js
+++ b/tests/initial-article-with-map.test.js
@@ -1,0 +1,20 @@
+import { jest, beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { isArticleLoaded } from "./utils/is-article-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+import { settings } from "./mocks/settings.js";
+
+jest.mock("./mocks/settings.js");
+
+mockFetch();
+
+describe("initial article with map", () => {
+    beforeEach(async () => {
+        settings.initialArticle = "article1";
+        await initDom([], { map: "map1" });
+    });
+
+    test("should not load article on start", () => {
+        expect(isArticleLoaded(null, "")).toBe(true);
+    });
+});

--- a/tests/initial-article-with-menu.test.js
+++ b/tests/initial-article-with-menu.test.js
@@ -1,0 +1,20 @@
+import { jest, beforeEach, describe, expect, test } from "@jest/globals";
+import { initDom } from "./utils/init-dom.js";
+import { isMenuLoaded } from "./utils/is-menu-loaded.js";
+import { mockFetch } from "./utils/mock-fetch.js";
+import { settings } from "./mocks/settings.js";
+
+jest.mock("./mocks/settings.js");
+
+mockFetch();
+
+describe("initial article with map", () => {
+    beforeEach(async () => {
+        settings.initialArticle = "article1";
+        await initDom([], { menu: "maps-index" });
+    });
+
+    test("should not load article on start", () => {
+        expect(isMenuLoaded("maps-index")).toBe(true);
+    });
+});


### PR DESCRIPTION
Initial article was loading when there were maps and menus on the initial URL, which is not intended. Now it only loads if none of the query strings used by the system (`article`, `map` and `menu`) aren't on the URL and there are better tests to catch it.