### PR TITLE
Improve search algorithm

### DIFF
--- a/src/components/search-bar.js
+++ b/src/components/search-bar.js
@@ -1,5 +1,16 @@
 import { setAnchors } from "./anchor.js";
 
+function setResultLink(title, data) {
+    const result = document.getElementById("search-result");
+    result.innerHTML = title;
+    if ("tomap" in data) result.setAttribute("tomap", data.tomap);
+    else result.removeAttribute("tomap");
+    if ("toarticle" in data) result.setAttribute("toarticle", data.toarticle);
+    else result.removeAttribute("toarticle");
+    result.classList.remove("hidden");
+    setAnchors([result]);
+}
+
 function search(input) {
     const result = document.getElementById("search-result");
     result.innerHTML = "";
@@ -8,21 +19,19 @@ function search(input) {
     if (!input) return;
 
     const pattern = new RegExp(input.split("").join(".*"), "i");
+    let hit = null;
     for (let i = 0; i < window.search.titles.length; i++) {
         const title = window.search.titles[i];
         if (pattern.test(title)) {
-            const data = window.search.table[title];
-            result.innerHTML = title;
-            if ("tomap" in data) result.setAttribute("tomap", data.tomap);
-            else result.removeAttribute("tomap");
-            if ("toarticle" in data)
-                result.setAttribute("toarticle", data.toarticle);
-            else result.removeAttribute("toarticle");
-            result.classList.remove("hidden");
-            setAnchors([result]);
-            return;
+            if (hit) {
+                hit = title.length < hit.length ? title : hit;
+            } else {
+                hit = title;
+            }
         }
     }
+
+    if (hit) setResultLink(hit, window.search.table[hit]);
 }
 
 export function getSearchBar() {


### PR DESCRIPTION
We would just send the first match to your input, so if you type the entire name of what you were looking for and that entire name is also contained by another match, you could get only reached by that name depending on the order it appears on the build file.

For example, if you're looking for an article called Blackwater but there's another article called Blackwater River, you could never find it by typing Blackwater as it would only give you Blackwater River as its match.