### PR TITLE
Fix minimize bug

### DIFF
--- a/src/components/article-modal.js
+++ b/src/components/article-modal.js
@@ -22,8 +22,10 @@ export function setArticleModal(content, articleTitle) {
 function minimizeArticle() {
     const mid = document.getElementById("article-container-mid");
     const link = document.getElementById("minimize-article-link");
+    const inner = document.getElementById("article-container-inner");
     mid.classList.add("h-8");
     mid.classList.remove("grow");
+    inner.classList.add("opacity-0");
     link.innerHTML = window.settings.labels.maximizeArticle;
     link.onclick = maximizeArticle;
 }
@@ -31,8 +33,10 @@ function minimizeArticle() {
 function maximizeArticle() {
     const mid = document.getElementById("article-container-mid");
     const link = document.getElementById("minimize-article-link");
+    const inner = document.getElementById("article-container-inner");
     mid.classList.remove("h-8");
     mid.classList.add("grow");
+    inner.classList.remove("opacity-0");
     link.innerHTML = window.settings.labels.minimizeArticle;
     link.onclick = minimizeArticle;
 }

--- a/tests/minimize-article-feature.test.js
+++ b/tests/minimize-article-feature.test.js
@@ -11,20 +11,24 @@ const SLEEP_TIME = 15;
 
 function isArticleModalMaximized() {
     const container = document.getElementById("article-container-mid");
+    const inner = document.getElementById("article-container-inner");
     const link = document.getElementById("minimize-article-link");
     return (
         !container.classList.contains("h-8") &&
         container.classList.contains("grow") &&
+        !inner.classList.contains("opacity-0") &&
         link.innerHTML === window.settings.labels.minimizeArticle
     );
 }
 
 function isArticleModalMinimized() {
     const container = document.getElementById("article-container-mid");
+    const inner = document.getElementById("article-container-inner");
     const link = document.getElementById("minimize-article-link");
     return (
         container.classList.contains("h-8") &&
         !container.classList.contains("grow") &&
+        inner.classList.contains("opacity-0") &&
         link.innerHTML === window.settings.labels.maximizeArticle
     );
 }


### PR DESCRIPTION
When minimizing an article, if there was half a line of text under the control panel, it would be rendered under the minimized bar. This commit fixes this bug.